### PR TITLE
Add web interface for MemoryLedger

### DIFF
--- a/MemoryLedgerApp/MemoryLedgerApp.csproj
+++ b/MemoryLedgerApp/MemoryLedgerApp.csproj
@@ -1,8 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <TargetFramework>net8.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 </Project>

--- a/MemoryLedgerApp/Models/Api/Contracts.cs
+++ b/MemoryLedgerApp/Models/Api/Contracts.cs
@@ -1,0 +1,27 @@
+namespace MemoryLedgerApp.Models.Api;
+
+public record ApiResponse(bool Success, string Message);
+
+public record ApiResponse<T>(bool Success, string Message, T? Data);
+
+public record CreateDiaryRequest(string Name, string Password);
+
+public record DiaryCredentials(string Name, string Password);
+
+public record DeleteDiaryRequest(string Name, string Password);
+
+public record AddEntryRequest(string DiaryName, string Password, DateTime Date, string Title, string Description, int Intensity);
+
+public record UpdateEntryRequest(string DiaryName, string Password, int EntryId, DateTime Date, string Title, string Description, int Intensity);
+
+public record DeleteEntryRequest(string DiaryName, string Password, int EntryId);
+
+public record SearchEntriesRequest(string DiaryName, string Password, string? Text, DateTime? Date, int? Intensity);
+
+public record AverageIntensityRequest(string DiaryName, string Password, DateTime? Start, DateTime? End);
+
+public record MemoryEntryDto(int Id, DateTime Date, string Title, string Description, int Intensity);
+
+public record DiaryDetailDto(string Name, IReadOnlyList<MemoryEntryDto> Entries);
+
+public record AverageIntensityResponse(double? Average, DateTime Start, DateTime End);

--- a/MemoryLedgerApp/Services/DiaryStorage.cs
+++ b/MemoryLedgerApp/Services/DiaryStorage.cs
@@ -27,7 +27,7 @@ public class DiaryStorage
     {
         if (DiaryExists(name))
         {
-            throw new InvalidOperationException($"Ya existe un diario con el nombre '{name}'.");
+            throw new InvalidOperationException($"A diary named '{name}' already exists.");
         }
 
         var diary = new Diary { Name = name };
@@ -39,7 +39,7 @@ public class DiaryStorage
         var path = GetDiaryPath(name);
         if (!File.Exists(path))
         {
-            throw new FileNotFoundException("El diario solicitado no existe.", path);
+            throw new FileNotFoundException("The requested diary does not exist.", path);
         }
 
         var encryptedBytes = await File.ReadAllBytesAsync(path, cancellationToken);
@@ -47,11 +47,11 @@ public class DiaryStorage
         {
             var json = EncryptionService.Decrypt(encryptedBytes, password);
             var diary = JsonSerializer.Deserialize<Diary>(json, SerializerOptions);
-            return diary ?? throw new InvalidDataException("No fue posible leer el contenido del diario.");
+            return diary ?? throw new InvalidDataException("Unable to read the diary content.");
         }
         catch (CryptographicException)
         {
-            throw new UnauthorizedAccessException("La clave proporcionada es incorrecta.");
+            throw new UnauthorizedAccessException("The provided password is incorrect.");
         }
     }
 

--- a/MemoryLedgerApp/wwwroot/app.js
+++ b/MemoryLedgerApp/wwwroot/app.js
@@ -1,0 +1,457 @@
+const diaryList = document.getElementById("diary-list");
+const messageBar = document.getElementById("message");
+const diaryView = document.getElementById("diary-view");
+const diaryTitle = document.getElementById("diary-title");
+const diarySubtitle = document.getElementById("diary-subtitle");
+const entriesContainer = document.getElementById("entries");
+const entriesEmpty = document.getElementById("entries-empty");
+const averageResult = document.getElementById("average-result");
+
+const createForm = document.getElementById("create-diary-form");
+const openForm = document.getElementById("open-diary-form");
+const deleteDiaryButton = document.getElementById("delete-diary");
+const refreshButton = document.getElementById("refresh-diary");
+const closeButton = document.getElementById("close-diary");
+const addEntryForm = document.getElementById("add-entry-form");
+const searchForm = document.getElementById("search-form");
+const resetSearchButton = document.getElementById("reset-search");
+const averageForm = document.getElementById("average-form");
+
+const entryDateInput = document.getElementById("entry-date");
+
+let currentDiary = null;
+let currentPassword = null;
+let entriesCache = [];
+
+const getToday = () => new Date().toISOString().slice(0, 10);
+entryDateInput.value = getToday();
+
+init();
+
+function init() {
+  loadDiaries();
+
+  createForm.addEventListener("submit", async (event) => {
+    event.preventDefault();
+    const formData = new FormData(createForm);
+    const payload = Object.fromEntries(formData.entries());
+
+    const response = await apiPost("/api/diaries/create", payload);
+    showMessage(response.message, response.ok ? "success" : "error");
+
+    if (response.ok) {
+      createForm.reset();
+      loadDiaries();
+    }
+  });
+
+  openForm.addEventListener("submit", async (event) => {
+    event.preventDefault();
+    await openDiaryFromForm();
+  });
+
+  deleteDiaryButton.addEventListener("click", async () => {
+    const name = openForm.name.value.trim();
+    const password = openForm.password.value.trim();
+
+    if (!name || !password) {
+      showMessage("Provide both the diary name and password to delete it.", "error");
+      return;
+    }
+
+    if (!confirm(`Delete the diary "${name}"? This action cannot be undone.`)) {
+      return;
+    }
+
+    const response = await apiPost("/api/diaries/delete", { name, password });
+    showMessage(response.message, response.ok ? "success" : "error");
+
+    if (response.ok) {
+      if (currentDiary === name) {
+        closeDiaryView();
+      }
+      loadDiaries();
+      openForm.reset();
+    }
+  });
+
+  refreshButton.addEventListener("click", async () => {
+    if (!currentDiary || !currentPassword) {
+      showMessage("Open a diary first.", "error");
+      return;
+    }
+
+    await openDiary(currentDiary, currentPassword, { silent: true });
+  });
+
+  closeButton.addEventListener("click", () => {
+    closeDiaryView();
+    showMessage("Diary closed.", "success");
+  });
+
+  addEntryForm.addEventListener("submit", async (event) => {
+    event.preventDefault();
+    if (!ensureDiaryOpen()) {
+      return;
+    }
+
+    const formData = new FormData(addEntryForm);
+    const payload = Object.fromEntries(formData.entries());
+    payload.diaryName = currentDiary;
+    payload.password = currentPassword;
+    payload.intensity = Number(payload.intensity);
+
+    const response = await apiPost("/api/entries/add", payload);
+    showMessage(response.message, response.ok ? "success" : "error");
+
+    if (response.ok) {
+      addEntryForm.reset();
+      entryDateInput.value = getToday();
+      await openDiary(currentDiary, currentPassword, { silent: true });
+    }
+  });
+
+  searchForm.addEventListener("submit", async (event) => {
+    event.preventDefault();
+    if (!ensureDiaryOpen()) {
+      return;
+    }
+
+    const formData = new FormData(searchForm);
+    const payload = Object.fromEntries(formData.entries());
+    payload.diaryName = currentDiary;
+    payload.password = currentPassword;
+    if (!payload.text) delete payload.text;
+    if (!payload.date) delete payload.date;
+    if (!payload.intensity) delete payload.intensity;
+
+    const response = await apiPost("/api/entries/search", payload);
+    showMessage(response.message, response.ok ? "success" : "error");
+
+    if (response.ok && response.data) {
+      renderEntries(response.data, { fromSearch: true });
+    }
+  });
+
+  resetSearchButton.addEventListener("click", () => {
+    searchForm.reset();
+    entryDateInput.value = getToday();
+    averageResult.textContent = "";
+    renderEntries(entriesCache);
+  });
+
+  averageForm.addEventListener("submit", async (event) => {
+    event.preventDefault();
+    if (!ensureDiaryOpen()) {
+      return;
+    }
+
+    const formData = new FormData(averageForm);
+    const payload = Object.fromEntries(formData.entries());
+    payload.diaryName = currentDiary;
+    payload.password = currentPassword;
+    if (!payload.start) delete payload.start;
+    if (!payload.end) delete payload.end;
+
+    const response = await apiPost("/api/entries/average", payload);
+    showMessage(response.message, response.ok ? "success" : "error");
+
+    if (response.ok && response.data) {
+      const { average, start, end } = response.data;
+      averageResult.textContent = average === null
+        ? "No memories in the selected range."
+        : `Average intensity from ${formatDate(start)} to ${formatDate(end)}: ${Number(average).toFixed(2)}`;
+    }
+  });
+
+  entriesContainer.addEventListener("click", async (event) => {
+    const button = event.target.closest("button[data-action]");
+    if (!button) return;
+
+    const entryId = Number(button.dataset.entryId);
+    if (Number.isNaN(entryId)) return;
+
+    if (button.dataset.action === "delete") {
+      await deleteEntry(entryId);
+    } else if (button.dataset.action === "edit") {
+      await editEntry(entryId);
+    }
+  });
+}
+
+async function openDiaryFromForm() {
+  const name = openForm.name.value.trim();
+  const password = openForm.password.value.trim();
+
+  if (!name || !password) {
+    showMessage("Both name and password are required to open a diary.", "error");
+    return;
+  }
+
+  await openDiary(name, password);
+}
+
+async function openDiary(name, password, options = {}) {
+  const response = await apiPost("/api/diaries/open", { name, password });
+  showMessage(response.message, response.ok ? "success" : "error", options.silent);
+
+  if (!response.ok || !response.data) {
+    return;
+  }
+
+  currentDiary = response.data.name;
+  currentPassword = password;
+  entriesCache = response.data.entries ?? [];
+
+  diaryTitle.textContent = currentDiary;
+  diarySubtitle.textContent = `${entriesCache.length} ${entriesCache.length === 1 ? "memory" : "memories"}`;
+  averageResult.textContent = "";
+
+  renderEntries(entriesCache);
+  diaryView.classList.remove("hidden");
+}
+
+function closeDiaryView() {
+  currentDiary = null;
+  currentPassword = null;
+  entriesCache = [];
+  diaryTitle.textContent = "";
+  diarySubtitle.textContent = "";
+  averageResult.textContent = "";
+  entriesContainer.innerHTML = "";
+  entriesEmpty.classList.remove("hidden");
+  diaryView.classList.add("hidden");
+}
+
+function ensureDiaryOpen() {
+  if (!currentDiary || !currentPassword) {
+    showMessage("Open a diary first.", "error");
+    return false;
+  }
+  return true;
+}
+
+async function deleteEntry(entryId) {
+  if (!ensureDiaryOpen()) {
+    return;
+  }
+
+  if (!confirm("Delete this memory?")) {
+    return;
+  }
+
+  const payload = {
+    diaryName: currentDiary,
+    password: currentPassword,
+    entryId,
+  };
+
+  const response = await apiPost("/api/entries/delete", payload);
+  showMessage(response.message, response.ok ? "success" : "error");
+
+  if (response.ok) {
+    await openDiary(currentDiary, currentPassword, { silent: true });
+  }
+}
+
+async function editEntry(entryId) {
+  if (!ensureDiaryOpen()) {
+    return;
+  }
+
+  const entry = entriesCache.find((item) => item.id === entryId);
+  if (!entry) {
+    showMessage("Memory not found in the current view.", "error");
+    return;
+  }
+
+  const updatedTitle = prompt("Title", entry.title);
+  if (updatedTitle === null) return;
+
+  const updatedDescription = prompt("Description", entry.description);
+  if (updatedDescription === null) return;
+
+  const updatedIntensityInput = prompt("Intensity (0-10)", entry.intensity);
+  if (updatedIntensityInput === null) return;
+  const updatedIntensity = Number(updatedIntensityInput);
+  if (Number.isNaN(updatedIntensity)) {
+    showMessage("Intensity must be a number between 0 and 10.", "error");
+    return;
+  }
+
+  const updatedDateInput = prompt("Date (YYYY-MM-DD)", formatDate(entry.date));
+  if (updatedDateInput === null) return;
+
+  const payload = {
+    diaryName: currentDiary,
+    password: currentPassword,
+    entryId,
+    title: updatedTitle.trim(),
+    description: updatedDescription.trim(),
+    intensity: updatedIntensity,
+    date: updatedDateInput,
+  };
+
+  const response = await apiPost("/api/entries/update", payload);
+  showMessage(response.message, response.ok ? "success" : "error");
+
+  if (response.ok) {
+    await openDiary(currentDiary, currentPassword, { silent: true });
+  }
+}
+
+function renderEntries(entries, options = {}) {
+  entriesContainer.innerHTML = "";
+
+  const list = Array.isArray(entries) ? entries : [];
+  if (list.length === 0) {
+    entriesEmpty.classList.remove("hidden");
+    return;
+  }
+
+  if (!options.fromSearch) {
+    entriesCache = list;
+  }
+
+  entriesEmpty.classList.add("hidden");
+
+  list.forEach((entry) => {
+    const element = document.createElement("article");
+    element.className = "entry";
+
+    const header = document.createElement("div");
+    header.className = "entry-header";
+
+    const title = document.createElement("div");
+    title.className = "entry-title";
+    title.textContent = entry.title;
+
+    const actions = document.createElement("div");
+    actions.className = "entry-actions";
+
+    const editButton = document.createElement("button");
+    editButton.type = "button";
+    editButton.className = "secondary";
+    editButton.dataset.action = "edit";
+    editButton.dataset.entryId = entry.id;
+    editButton.textContent = "Edit";
+
+    const deleteButton = document.createElement("button");
+    deleteButton.type = "button";
+    deleteButton.className = "danger";
+    deleteButton.dataset.action = "delete";
+    deleteButton.dataset.entryId = entry.id;
+    deleteButton.textContent = "Delete";
+
+    actions.append(editButton, deleteButton);
+    header.append(title, actions);
+
+    const meta = document.createElement("div");
+    meta.className = "entry-meta";
+    meta.textContent = `${formatDate(entry.date)} • Intensity ${entry.intensity}`;
+
+    const description = document.createElement("p");
+    description.textContent = entry.description;
+
+    element.append(header, meta, description);
+    entriesContainer.append(element);
+  });
+}
+
+function showMessage(text, type = "success", silent = false) {
+  if (silent || !text) {
+    return;
+  }
+
+  messageBar.textContent = text;
+  messageBar.classList.remove("hidden", "success", "error");
+  messageBar.classList.add(type === "error" ? "error" : "success");
+
+  clearTimeout(showMessage.timeoutId);
+  showMessage.timeoutId = setTimeout(() => {
+    messageBar.classList.add("hidden");
+  }, 5000);
+}
+
+async function loadDiaries() {
+  const response = await apiGet("/api/diaries");
+  if (!response.ok || !response.data) {
+    showMessage(response.message || "Unable to load diaries.", "error");
+    return;
+  }
+
+  diaryList.innerHTML = "";
+  if (response.data.length === 0) {
+    const empty = document.createElement("li");
+    empty.textContent = "No diaries yet.";
+    empty.className = "hint";
+    diaryList.append(empty);
+    return;
+  }
+
+  response.data.forEach((name) => {
+    const item = document.createElement("li");
+    item.textContent = name;
+    item.tabIndex = 0;
+    item.addEventListener("click", () => {
+      openForm.name.value = name;
+      openForm.name.focus();
+    });
+    item.addEventListener("keydown", (event) => {
+      if (event.key === "Enter" || event.key === " ") {
+        event.preventDefault();
+        openForm.name.value = name;
+        openForm.name.focus();
+      }
+    });
+    diaryList.append(item);
+  });
+}
+
+async function apiPost(url, payload) {
+  try {
+    const response = await fetch(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+    });
+
+    const data = await safeJson(response);
+    return { ok: response.ok, status: response.status, ...data };
+  } catch (error) {
+    console.error(error);
+    return { ok: false, status: 0, message: "Network error." };
+  }
+}
+
+async function apiGet(url) {
+  try {
+    const response = await fetch(url);
+    const data = await safeJson(response);
+    return { ok: response.ok, status: response.status, ...data };
+  } catch (error) {
+    console.error(error);
+    return { ok: false, status: 0, message: "Network error." };
+  }
+}
+
+async function safeJson(response) {
+  try {
+    const data = await response.json();
+    return {
+      message: data.message,
+      data: data.data,
+    };
+  } catch {
+    return { message: "Unexpected server response." };
+  }
+}
+
+function formatDate(value) {
+  if (!value) return "";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+  return date.toISOString().slice(0, 10);
+}

--- a/MemoryLedgerApp/wwwroot/index.html
+++ b/MemoryLedgerApp/wwwroot/index.html
@@ -1,0 +1,104 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>MemoryLedger</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <header class="app-header">
+      <h1>MemoryLedger</h1>
+      <p>Encrypted diaries to remember the moments that matter.</p>
+    </header>
+    <main class="app-layout">
+      <aside class="sidebar">
+        <section class="card">
+          <h2>Available diaries</h2>
+          <ul id="diary-list" class="diary-list"></ul>
+          <p class="hint">Use the password field below to open or delete a diary.</p>
+        </section>
+        <section class="card">
+          <h2>Create a diary</h2>
+          <form id="create-diary-form" class="form-grid">
+            <label for="create-name">Name</label>
+            <input id="create-name" name="name" type="text" required />
+            <label for="create-password">Password</label>
+            <input id="create-password" name="password" type="password" required />
+            <button type="submit" class="primary">Create diary</button>
+          </form>
+        </section>
+      </aside>
+      <section class="content">
+        <div id="message" class="message hidden" role="status" aria-live="polite"></div>
+        <section class="card">
+          <h2>Open a diary</h2>
+          <form id="open-diary-form" class="form-grid">
+            <label for="open-name">Name</label>
+            <input id="open-name" name="name" type="text" required />
+            <label for="open-password">Password</label>
+            <input id="open-password" name="password" type="password" required />
+            <div class="button-row">
+              <button type="submit" class="primary">Open diary</button>
+              <button type="button" id="delete-diary" class="danger">Delete diary</button>
+            </div>
+          </form>
+        </section>
+        <section id="diary-view" class="card hidden">
+          <div class="diary-header">
+            <div>
+              <h2 id="diary-title"></h2>
+              <p id="diary-subtitle" class="hint"></p>
+            </div>
+            <div class="button-row">
+              <button type="button" id="refresh-diary" class="secondary">Refresh</button>
+              <button type="button" id="close-diary" class="secondary">Close</button>
+            </div>
+          </div>
+          <section class="forms-grid">
+            <form id="add-entry-form" class="form-grid">
+              <h3>Add a memory</h3>
+              <label for="entry-date">Date</label>
+              <input id="entry-date" name="date" type="date" required />
+              <label for="entry-title">Title</label>
+              <input id="entry-title" name="title" type="text" required />
+              <label for="entry-description">Description</label>
+              <textarea id="entry-description" name="description" rows="3" required></textarea>
+              <label for="entry-intensity">Intensity (0-10)</label>
+              <input id="entry-intensity" name="intensity" type="number" min="0" max="10" value="5" required />
+              <button type="submit" class="primary">Save memory</button>
+            </form>
+            <form id="search-form" class="form-grid">
+              <h3>Search memories</h3>
+              <label for="search-text">Text in title or description</label>
+              <input id="search-text" name="text" type="text" placeholder="Optional" />
+              <label for="search-date">Exact date</label>
+              <input id="search-date" name="date" type="date" />
+              <label for="search-intensity">Exact intensity</label>
+              <input id="search-intensity" name="intensity" type="number" min="0" max="10" />
+              <div class="button-row">
+                <button type="submit" class="secondary">Search</button>
+                <button type="button" id="reset-search" class="secondary">Reset</button>
+              </div>
+            </form>
+            <form id="average-form" class="form-grid">
+              <h3>Average intensity</h3>
+              <label for="average-start">Start date</label>
+              <input id="average-start" name="start" type="date" />
+              <label for="average-end">End date</label>
+              <input id="average-end" name="end" type="date" />
+              <button type="submit" class="secondary">Calculate</button>
+              <p id="average-result" class="hint"></p>
+            </form>
+          </section>
+          <section>
+            <h3>Memories</h3>
+            <p id="entries-empty" class="hint">No memories recorded yet.</p>
+            <div id="entries" class="entries"></div>
+          </section>
+        </section>
+      </section>
+    </main>
+    <script src="app.js" type="module"></script>
+  </body>
+</html>

--- a/MemoryLedgerApp/wwwroot/styles.css
+++ b/MemoryLedgerApp/wwwroot/styles.css
@@ -1,0 +1,254 @@
+:root {
+  color-scheme: light dark;
+  font-family: "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  background: #f3f4f6;
+  color: #1f2933;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+}
+
+h1,
+h2,
+h3 {
+  margin: 0 0 0.5rem;
+  color: #14213d;
+}
+
+p {
+  margin: 0 0 0.5rem;
+}
+
+.app-header {
+  background: linear-gradient(120deg, #1d4ed8, #3b82f6);
+  color: #ffffff;
+  text-align: center;
+  padding: 2.5rem 1rem 2rem;
+  box-shadow: 0 6px 18px rgba(30, 64, 175, 0.35);
+}
+
+.app-header p {
+  max-width: 640px;
+  margin: 0.5rem auto 0;
+  font-size: 1.05rem;
+  opacity: 0.9;
+}
+
+.app-layout {
+  display: grid;
+  grid-template-columns: minmax(260px, 320px) 1fr;
+  gap: 1.5rem;
+  padding: 2rem clamp(1rem, 4vw, 3rem) 3rem;
+}
+
+.sidebar {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.card {
+  background: #ffffff;
+  border-radius: 16px;
+  padding: 1.5rem;
+  box-shadow: 0 12px 32px rgba(15, 23, 42, 0.08);
+  border: 1px solid rgba(148, 163, 184, 0.3);
+}
+
+.hint {
+  font-size: 0.9rem;
+  color: #52606d;
+}
+
+.message {
+  padding: 1rem 1.25rem;
+  border-radius: 12px;
+  margin-bottom: 1.25rem;
+  font-weight: 600;
+  transition: opacity 0.2s ease;
+}
+
+.message.success {
+  background: rgba(16, 185, 129, 0.1);
+  color: #047857;
+  border: 1px solid rgba(16, 185, 129, 0.4);
+}
+
+.message.error {
+  background: rgba(239, 68, 68, 0.1);
+  color: #b91c1c;
+  border: 1px solid rgba(239, 68, 68, 0.4);
+}
+
+.diary-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.diary-list li {
+  background: rgba(59, 130, 246, 0.08);
+  border-radius: 10px;
+  padding: 0.65rem 0.75rem;
+  font-weight: 600;
+  color: #1d4ed8;
+}
+
+.form-grid {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.forms-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.25rem;
+  margin-bottom: 2rem;
+}
+
+.form-grid input,
+.form-grid textarea,
+.form-grid button {
+  width: 100%;
+  box-sizing: border-box;
+}
+
+input,
+textarea,
+select {
+  padding: 0.65rem 0.75rem;
+  border-radius: 10px;
+  border: 1px solid rgba(148, 163, 184, 0.6);
+  background: #f8fafc;
+  font: inherit;
+  color: inherit;
+}
+
+textarea {
+  resize: vertical;
+}
+
+button {
+  border: none;
+  border-radius: 999px;
+  padding: 0.6rem 1.2rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.1s ease, box-shadow 0.2s ease;
+}
+
+button:active {
+  transform: scale(0.98);
+}
+
+button.primary {
+  background: linear-gradient(120deg, #2563eb, #1d4ed8);
+  color: #ffffff;
+  box-shadow: 0 10px 20px rgba(37, 99, 235, 0.35);
+}
+
+button.secondary {
+  background: rgba(37, 99, 235, 0.12);
+  color: #1d4ed8;
+}
+
+button.danger {
+  background: rgba(239, 68, 68, 0.15);
+  color: #b91c1c;
+}
+
+.button-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.diary-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+}
+
+.entries {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  margin-top: 1rem;
+}
+
+.entry {
+  background: #f1f5f9;
+  border-radius: 14px;
+  padding: 1.2rem;
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  display: grid;
+  gap: 0.5rem;
+}
+
+.entry-header {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.entry-title {
+  font-weight: 700;
+  font-size: 1.05rem;
+}
+
+.entry-actions {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.entry-meta {
+  font-size: 0.9rem;
+  color: #52606d;
+}
+
+.hidden {
+  display: none !important;
+}
+
+@media (max-width: 1024px) {
+  .app-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .sidebar {
+    flex-direction: row;
+    flex-wrap: wrap;
+  }
+
+  .sidebar .card {
+    flex: 1 1 280px;
+  }
+}
+
+@media (max-width: 640px) {
+  .forms-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .diary-header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  button {
+    width: 100%;
+  }
+
+  .button-row {
+    width: 100%;
+  }
+}


### PR DESCRIPTION
## Summary
- convert the console entry point into a minimal web API that serves diary management endpoints and static assets
- add DTO contracts plus an English front-end with forms for creating, opening, and managing encrypted diaries
- update storage error messages so the UI surfaces English feedback

## Testing
- `dotnet build` *(fails: command not found in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d776b29f98832690cdac89224bc226