### PR TITLE
Switch memory add/edit workflow to modal dialog

### DIFF
--- a/MemoryLedgerApp/wwwroot/index.html
+++ b/MemoryLedgerApp/wwwroot/index.html
@@ -51,23 +51,12 @@
               <p id="diary-subtitle" class="hint"></p>
             </div>
             <div class="button-row">
+              <button type="button" id="add-entry" class="primary">Add memory</button>
               <button type="button" id="refresh-diary" class="secondary">Refresh</button>
               <button type="button" id="close-diary" class="secondary">Close</button>
             </div>
           </div>
           <section class="forms-grid">
-            <form id="add-entry-form" class="form-grid">
-              <h3>Add a memory</h3>
-              <label for="entry-date">Date</label>
-              <input id="entry-date" name="date" type="date" required />
-              <label for="entry-title">Title</label>
-              <input id="entry-title" name="title" type="text" required />
-              <label for="entry-description">Description</label>
-              <textarea id="entry-description" name="description" rows="3" required></textarea>
-              <label for="entry-intensity">Intensity (0-10)</label>
-              <input id="entry-intensity" name="intensity" type="number" min="0" max="10" value="5" required />
-              <button type="submit" class="primary">Save memory</button>
-            </form>
             <form id="search-form" class="form-grid">
               <h3>Search memories</h3>
               <label for="search-text">Text in title or description</label>
@@ -99,6 +88,28 @@
         </section>
       </section>
     </main>
+    <div id="entry-modal" class="modal hidden" role="dialog" aria-modal="true" aria-labelledby="entry-modal-title">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h2 id="entry-modal-title">Add memory</h2>
+          <button type="button" id="entry-close" class="icon-button" aria-label="Close">×</button>
+        </div>
+        <form id="entry-form" class="form-grid">
+          <label for="entry-date">Date</label>
+          <input id="entry-date" name="date" type="date" required />
+          <label for="entry-title">Title</label>
+          <input id="entry-title" name="title" type="text" required />
+          <label for="entry-description">Description</label>
+          <textarea id="entry-description" name="description" rows="4" required></textarea>
+          <label for="entry-intensity">Intensity (0-10)</label>
+          <input id="entry-intensity" name="intensity" type="number" min="0" max="10" value="5" required />
+          <div class="modal-actions">
+            <button type="button" id="entry-cancel" class="secondary">Cancel</button>
+            <button type="submit" id="entry-submit" class="primary">Save memory</button>
+          </div>
+        </form>
+      </div>
+    </div>
     <script src="app.js" type="module"></script>
   </body>
 </html>

--- a/MemoryLedgerApp/wwwroot/styles.css
+++ b/MemoryLedgerApp/wwwroot/styles.css
@@ -176,6 +176,10 @@ button.danger {
   margin-bottom: 1.5rem;
 }
 
+.diary-header .button-row {
+  justify-content: flex-end;
+}
+
 .entries {
   display: flex;
   flex-direction: column;
@@ -197,6 +201,63 @@ button.danger {
   justify-content: space-between;
   gap: 0.75rem;
   flex-wrap: wrap;
+}
+
+.modal {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.45);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1.5rem;
+  z-index: 1000;
+}
+
+.modal.hidden {
+  display: none;
+}
+
+.modal-content {
+  background: #ffffff;
+  border-radius: 18px;
+  max-width: min(520px, 100%);
+  width: min(520px, 100%);
+  padding: 1.75rem;
+  box-shadow: 0 20px 60px rgba(15, 23, 42, 0.25);
+  border: 1px solid rgba(148, 163, 184, 0.35);
+}
+
+.modal-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1rem;
+  gap: 1rem;
+}
+
+.modal-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
+  margin-top: 0.5rem;
+}
+
+.icon-button {
+  background: transparent;
+  color: inherit;
+  font-size: 1.5rem;
+  line-height: 1;
+  padding: 0.25rem 0.5rem;
+  border-radius: 50%;
+}
+
+.icon-button:hover {
+  background: rgba(15, 23, 42, 0.08);
+}
+
+body.modal-open {
+  overflow: hidden;
 }
 
 .entry-title {


### PR DESCRIPTION
## Summary
- replace the inline memory form with a modal dialog launched from the diary view
- reuse the modal for both creating and editing entries and update the front-end logic
- add styling and focus management for the modal experience

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d7f48093748326bc45060f816118e3