### PR TITLE
Add statistics modal with line chart visualization

### DIFF
--- a/MemoryLedgerApp/wwwroot/app.js
+++ b/MemoryLedgerApp/wwwroot/app.js
@@ -16,12 +16,21 @@ const addEntryButton = document.getElementById("add-entry");
 const searchForm = document.getElementById("search-form");
 const resetSearchButton = document.getElementById("reset-search");
 const averageForm = document.getElementById("average-form");
+const averageStartInput = document.getElementById("average-start");
+const averageEndInput = document.getElementById("average-end");
+const statisticsButton = document.getElementById("statistics-button");
 const entryModal = document.getElementById("entry-modal");
 const entryModalTitle = document.getElementById("entry-modal-title");
 const entryForm = document.getElementById("entry-form");
 const entrySubmitButton = document.getElementById("entry-submit");
 const entryCancelButton = document.getElementById("entry-cancel");
 const entryCloseButton = document.getElementById("entry-close");
+const statsModal = document.getElementById("stats-modal");
+const statsCloseButton = document.getElementById("stats-close");
+const statsAverageText = document.getElementById("stats-average");
+const statsChartWrapper = document.getElementById("stats-chart-wrapper");
+const statsCanvas = document.getElementById("stats-chart");
+const statsEmpty = document.getElementById("stats-empty");
 
 const entryDateInput = document.getElementById("entry-date");
 const entryTitleInput = document.getElementById("entry-title");
@@ -32,6 +41,8 @@ let currentDiary = null;
 let currentPassword = null;
 let entriesCache = [];
 let editingEntryId = null;
+let statsChartInstance = null;
+let chartLibrary = null;
 
 const getToday = () => new Date().toISOString().slice(0, 10);
 entryDateInput.value = getToday();
@@ -40,6 +51,10 @@ init();
 
 function init() {
   loadDiaries();
+
+  if (statisticsButton) {
+    statisticsButton.disabled = true;
+  }
 
   createForm.addEventListener("submit", async (event) => {
     event.preventDefault();
@@ -122,7 +137,13 @@ function init() {
   });
 
   document.addEventListener("keydown", (event) => {
-    if (event.key === "Escape" && !entryModal.classList.contains("hidden")) {
+    if (event.key !== "Escape") {
+      return;
+    }
+
+    if (isStatsModalOpen()) {
+      closeStatisticsModal();
+    } else if (!entryModal.classList.contains("hidden")) {
       closeEntryModal();
     }
   });
@@ -181,7 +202,7 @@ function init() {
   resetSearchButton.addEventListener("click", () => {
     searchForm.reset();
     entryDateInput.value = getToday();
-    averageResult.textContent = "";
+    averageForm.reset();
     renderEntries(entriesCache);
   });
 
@@ -191,21 +212,46 @@ function init() {
       return;
     }
 
-    const formData = new FormData(averageForm);
-    const payload = Object.fromEntries(formData.entries());
-    payload.diaryName = currentDiary;
-    payload.password = currentPassword;
-    if (!payload.start) delete payload.start;
-    if (!payload.end) delete payload.end;
+    const stats = collectStatistics();
+    updateAverageSummary(stats);
+    updateStatisticsButtonState(stats);
+    if (statisticsButton.disabled) {
+      return;
+    }
 
-    const response = await apiPost("/api/entries/average", payload);
-    showMessage(response.message, response.ok ? "success" : "error");
+    await openStatisticsModal();
+  });
 
-    if (response.ok && response.data) {
-      const { average, start, end } = response.data;
-      averageResult.textContent = average === null
-        ? "No memories in the selected range."
-        : `Average intensity from ${formatDate(start)} to ${formatDate(end)}: ${Number(average).toFixed(2)}`;
+  [averageStartInput, averageEndInput].forEach((input) => {
+    input.addEventListener("input", () => {
+      if (!ensureDiaryOpen()) {
+        return;
+      }
+
+      const stats = collectStatistics();
+      updateAverageSummary(stats);
+      updateStatisticsButtonState(stats);
+      if (isStatsModalOpen()) {
+        renderStatisticsChart(stats);
+      }
+    });
+  });
+
+  statisticsButton.addEventListener("click", async () => {
+    if (!ensureDiaryOpen()) {
+      return;
+    }
+
+    await openStatisticsModal();
+  });
+
+  statsCloseButton.addEventListener("click", () => {
+    closeStatisticsModal();
+  });
+
+  statsModal.addEventListener("click", (event) => {
+    if (event.target === statsModal) {
+      closeStatisticsModal();
     }
   });
 
@@ -250,8 +296,7 @@ async function openDiary(name, password, options = {}) {
 
   diaryTitle.textContent = currentDiary;
   diarySubtitle.textContent = `${entriesCache.length} ${entriesCache.length === 1 ? "memory" : "memories"}`;
-  averageResult.textContent = "";
-
+  averageForm.reset();
   renderEntries(entriesCache);
   diaryView.classList.remove("hidden");
 }
@@ -262,7 +307,17 @@ function closeDiaryView() {
   entriesCache = [];
   diaryTitle.textContent = "";
   diarySubtitle.textContent = "";
+  averageForm.reset();
   averageResult.textContent = "";
+  statsAverageText.textContent = "";
+  if (statisticsButton) {
+    statisticsButton.disabled = true;
+    statisticsButton.removeAttribute("title");
+  }
+  closeStatisticsModal();
+  statsChartWrapper.classList.add("hidden");
+  statsEmpty.classList.add("hidden");
+  statsEmpty.textContent = "";
   entriesContainer.innerHTML = "";
   entriesEmpty.classList.remove("hidden");
   diaryView.classList.add("hidden");
@@ -342,23 +397,31 @@ function openEntryModal(mode, entry) {
 function closeEntryModal() {
   editingEntryId = null;
   entryModal.classList.add("hidden");
-  document.body.classList.remove("modal-open");
   entryForm.reset();
   entryDateInput.value = getToday();
   entryIntensityInput.value = 5;
+  if (!isAnyModalOpen()) {
+    document.body.classList.remove("modal-open");
+  }
 }
 
 function renderEntries(entries, options = {}) {
   entriesContainer.innerHTML = "";
 
   const list = Array.isArray(entries) ? entries : [];
+  if (!options.fromSearch) {
+    entriesCache = list;
+    const stats = collectStatistics();
+    updateAverageSummary(stats);
+    updateStatisticsButtonState(stats);
+    if (isStatsModalOpen()) {
+      renderStatisticsChart(stats);
+    }
+  }
+
   if (list.length === 0) {
     entriesEmpty.classList.remove("hidden");
     return;
-  }
-
-  if (!options.fromSearch) {
-    entriesCache = list;
   }
 
   entriesEmpty.classList.add("hidden");
@@ -404,6 +467,281 @@ function renderEntries(entries, options = {}) {
     element.append(header, meta, description);
     entriesContainer.append(element);
   });
+}
+
+function collectStatistics() {
+  const start = averageStartInput.value || "";
+  const end = averageEndInput.value || "";
+  const hasEntries = entriesCache.length > 0;
+  const invalidRange = Boolean(start && end && start > end);
+
+  if (!hasEntries) {
+    return { start, end, invalidRange, entries: [], average: null, hasEntries };
+  }
+
+  const normalizedEntries = entriesCache
+    .map((entry) => {
+      const normalizedDate = (formatDate(entry.date) || "").slice(0, 10);
+      if (!normalizedDate) {
+        return null;
+      }
+      return { ...entry, normalizedDate };
+    })
+    .filter(Boolean);
+
+  const filtered = normalizedEntries.filter((entry) => {
+    if (start && entry.normalizedDate < start) return false;
+    if (end && entry.normalizedDate > end) return false;
+    return true;
+  });
+
+  filtered.sort((a, b) => a.normalizedDate.localeCompare(b.normalizedDate));
+
+  const average =
+    filtered.length > 0
+      ? filtered.reduce((sum, entry) => sum + Number(entry.intensity ?? 0), 0) / filtered.length
+      : null;
+
+  return { start, end, invalidRange, entries: filtered, average, hasEntries };
+}
+
+function describeRange({ start, end }) {
+  if (start && end) {
+    return `from ${formatDate(start)} to ${formatDate(end)}`;
+  }
+  if (start) {
+    return `from ${formatDate(start)} onward`;
+  }
+  if (end) {
+    return `up to ${formatDate(end)}`;
+  }
+  return "for all memories";
+}
+
+function updateAverageSummary(stats = collectStatistics()) {
+  if (!currentDiary) {
+    averageResult.textContent = "";
+    statsAverageText.textContent = "";
+    return stats;
+  }
+
+  if (!stats.hasEntries) {
+    const message = "No memories recorded yet.";
+    averageResult.textContent = message;
+    statsAverageText.textContent = message;
+    return stats;
+  }
+
+  if (stats.invalidRange) {
+    const message = "Start date cannot be after end date.";
+    averageResult.textContent = message;
+    statsAverageText.textContent = message;
+    return stats;
+  }
+
+  if (stats.entries.length === 0) {
+    const message = "No memories in the selected range.";
+    averageResult.textContent = message;
+    statsAverageText.textContent = message;
+    return stats;
+  }
+
+  const averageValue = Number(stats.average).toFixed(2);
+  const summary = `Average intensity ${describeRange(stats)}: ${averageValue}`;
+  averageResult.textContent = summary;
+  statsAverageText.textContent = summary;
+  return stats;
+}
+
+function updateStatisticsButtonState(stats = collectStatistics()) {
+  if (!statisticsButton) {
+    return stats;
+  }
+
+  const disabled = !currentDiary || !stats.hasEntries || stats.invalidRange;
+  statisticsButton.disabled = disabled;
+
+  if (disabled && stats.invalidRange) {
+    statisticsButton.title = "Select a valid period (start date cannot be after end date).";
+  } else if (disabled && !stats.hasEntries) {
+    statisticsButton.title = "Add memories to view statistics.";
+  } else {
+    statisticsButton.removeAttribute("title");
+  }
+
+  return stats;
+}
+
+function isStatsModalOpen() {
+  return !statsModal.classList.contains("hidden");
+}
+
+function isAnyModalOpen() {
+  return !entryModal.classList.contains("hidden") || isStatsModalOpen();
+}
+
+async function openStatisticsModal() {
+  statsModal.classList.remove("hidden");
+  document.body.classList.add("modal-open");
+  await renderStatisticsChart();
+}
+
+function closeStatisticsModal() {
+  if (statsModal.classList.contains("hidden")) {
+    return;
+  }
+
+  statsModal.classList.add("hidden");
+  statsEmpty.classList.add("hidden");
+  statsEmpty.textContent = "";
+  if (!isAnyModalOpen()) {
+    document.body.classList.remove("modal-open");
+  }
+}
+
+async function renderStatisticsChart(statsData) {
+  try {
+    const stats = statsData ?? collectStatistics();
+    updateAverageSummary(stats);
+    updateStatisticsButtonState(stats);
+
+    if (!stats.hasEntries) {
+      showStatsMessage("No memories recorded yet.");
+      return;
+    }
+
+    if (stats.invalidRange) {
+      showStatsMessage("Start date cannot be after end date.");
+      return;
+    }
+
+    if (stats.entries.length === 0) {
+      showStatsMessage("No memories in the selected range.");
+      return;
+    }
+
+    const Chart = await loadChartLibrary();
+    if (!Chart) {
+      showStatsMessage("Unable to load the chart library.");
+      return;
+    }
+
+    showStatsChart();
+
+    const labels = stats.entries.map((entry) => entry.normalizedDate);
+    const intensities = stats.entries.map((entry) => Number(entry.intensity ?? 0));
+    const averageFixed = Number(stats.average.toFixed(2));
+    const averageData = labels.map(() => averageFixed);
+
+    if (!statsChartInstance) {
+      const context = statsCanvas.getContext("2d");
+      if (!context) {
+        showStatsMessage("Unable to render the chart.");
+        return;
+      }
+
+      statsChartInstance = new Chart(context, {
+        type: "line",
+        data: {
+          labels,
+          datasets: [
+            {
+              label: "Intensity",
+              data: intensities,
+              borderColor: "#2563eb",
+              backgroundColor: "rgba(37, 99, 235, 0.15)",
+              tension: 0.3,
+              fill: false,
+              pointBackgroundColor: "#2563eb",
+              pointRadius: 4,
+              pointHoverRadius: 6,
+            },
+            {
+              label: "Average",
+              data: averageData,
+              borderColor: "#f97316",
+              borderDash: [6, 6],
+              borderWidth: 2,
+              fill: false,
+              pointRadius: 0,
+              pointHoverRadius: 0,
+            },
+          ],
+        },
+        options: {
+          responsive: true,
+          maintainAspectRatio: false,
+          interaction: { intersect: false, mode: "index" },
+          scales: {
+            y: {
+              beginAtZero: true,
+              suggestedMin: 0,
+              suggestedMax: 10,
+              title: { display: true, text: "Intensity" },
+            },
+            x: {
+              title: { display: true, text: "Date" },
+            },
+          },
+          plugins: {
+            legend: {
+              labels: { usePointStyle: true },
+            },
+            tooltip: {
+              callbacks: {
+                label(context) {
+                  if (context.datasetIndex === 1) {
+                    return `Average: ${Number(context.parsed.y).toFixed(2)}`;
+                  }
+                  return `Intensity: ${context.parsed.y}`;
+                },
+              },
+            },
+          },
+        },
+      });
+    } else {
+      statsChartInstance.data.labels = labels;
+      statsChartInstance.data.datasets[0].data = intensities;
+      statsChartInstance.data.datasets[1].data = averageData;
+      statsChartInstance.update();
+    }
+  } catch (error) {
+    console.error(error);
+    showStatsMessage("Unable to render the chart.");
+  }
+}
+
+async function loadChartLibrary() {
+  if (chartLibrary) {
+    return chartLibrary;
+  }
+
+  if (globalThis.Chart) {
+    chartLibrary = globalThis.Chart;
+    return chartLibrary;
+  }
+
+  try {
+    const module = await import("https://cdn.jsdelivr.net/npm/chart.js@4.4.5/dist/chart.umd.min.js");
+    chartLibrary = module?.Chart || module?.default || globalThis.Chart;
+    return chartLibrary;
+  } catch (error) {
+    console.error("Failed to load chart library", error);
+    showMessage("Unable to load the chart library.", "error");
+    return null;
+  }
+}
+
+function showStatsChart() {
+  statsChartWrapper.classList.remove("hidden");
+  statsEmpty.classList.add("hidden");
+}
+
+function showStatsMessage(message) {
+  statsChartWrapper.classList.add("hidden");
+  statsEmpty.textContent = message;
+  statsEmpty.classList.remove("hidden");
 }
 
 function showMessage(text, type = "success", silent = false) {

--- a/MemoryLedgerApp/wwwroot/index.html
+++ b/MemoryLedgerApp/wwwroot/index.html
@@ -76,7 +76,7 @@
               <input id="average-start" name="start" type="date" />
               <label for="average-end">End date</label>
               <input id="average-end" name="end" type="date" />
-              <button type="submit" class="secondary">Calculate</button>
+              <button type="submit" id="statistics-button" class="secondary">View statistics</button>
               <p id="average-result" class="hint"></p>
             </form>
           </section>
@@ -88,6 +88,19 @@
         </section>
       </section>
     </main>
+    <div id="stats-modal" class="modal hidden" role="dialog" aria-modal="true" aria-labelledby="stats-modal-title">
+      <div class="modal-content stats-modal-content">
+        <div class="modal-header">
+          <h2 id="stats-modal-title">Diary statistics</h2>
+          <button type="button" id="stats-close" class="icon-button" aria-label="Close">×</button>
+        </div>
+        <p id="stats-average" class="hint"></p>
+        <div id="stats-chart-wrapper" class="stats-chart-wrapper hidden">
+          <canvas id="stats-chart" aria-label="Diary intensity chart" role="img"></canvas>
+        </div>
+        <p id="stats-empty" class="hint hidden"></p>
+      </div>
+    </div>
     <div id="entry-modal" class="modal hidden" role="dialog" aria-modal="true" aria-labelledby="entry-modal-title">
       <div class="modal-content">
         <div class="modal-header">

--- a/MemoryLedgerApp/wwwroot/styles.css
+++ b/MemoryLedgerApp/wwwroot/styles.css
@@ -146,6 +146,12 @@ button:active {
   transform: scale(0.98);
 }
 
+button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
 button.primary {
   background: linear-gradient(120deg, #2563eb, #1d4ed8);
   color: #ffffff;
@@ -228,6 +234,11 @@ button.danger {
   border: 1px solid rgba(148, 163, 184, 0.35);
 }
 
+.stats-modal-content {
+  max-width: min(720px, 100%);
+  width: min(720px, 100%);
+}
+
 .modal-header {
   display: flex;
   justify-content: space-between;
@@ -258,6 +269,27 @@ button.danger {
 
 body.modal-open {
   overflow: hidden;
+}
+
+#stats-average {
+  margin-bottom: 0.75rem;
+}
+
+.stats-chart-wrapper {
+  position: relative;
+  width: 100%;
+  height: 320px;
+  margin-top: 1.25rem;
+}
+
+.stats-chart-wrapper canvas {
+  width: 100% !important;
+  height: 100% !important;
+}
+
+#stats-empty {
+  margin-top: 1.25rem;
+  text-align: center;
 }
 
 .entry-title {


### PR DESCRIPTION
## Summary
- add a dedicated statistics modal that renders diary intensities on a line chart with a dotted average line
- filter memories by the selected date range on the client and keep the textual summary in sync with the chart
- extend styling to support the wider modal, chart layout, and disabled statistics button states

## Testing
- dotnet build (fails: `dotnet` command not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d8b58524b8832685fa36fce88cd029