### PR TITLE
Move statistics controls into modal

### DIFF
--- a/MemoryLedgerApp/wwwroot/app.js
+++ b/MemoryLedgerApp/wwwroot/app.js
@@ -219,6 +219,11 @@ function init() {
       return;
     }
 
+    if (isStatsModalOpen()) {
+      await renderStatisticsChart(stats);
+      return;
+    }
+
     await openStatisticsModal();
   });
 
@@ -308,8 +313,12 @@ function closeDiaryView() {
   diaryTitle.textContent = "";
   diarySubtitle.textContent = "";
   averageForm.reset();
-  averageResult.textContent = "";
-  statsAverageText.textContent = "";
+  if (averageResult) {
+    averageResult.textContent = "";
+  }
+  if (statsAverageText) {
+    statsAverageText.textContent = "";
+  }
   if (statisticsButton) {
     statisticsButton.disabled = true;
     statisticsButton.removeAttribute("title");
@@ -520,36 +529,56 @@ function describeRange({ start, end }) {
 
 function updateAverageSummary(stats = collectStatistics()) {
   if (!currentDiary) {
-    averageResult.textContent = "";
-    statsAverageText.textContent = "";
+    if (averageResult) {
+      averageResult.textContent = "";
+    }
+    if (statsAverageText) {
+      statsAverageText.textContent = "";
+    }
     return stats;
   }
 
   if (!stats.hasEntries) {
     const message = "No memories recorded yet.";
-    averageResult.textContent = message;
-    statsAverageText.textContent = message;
+    if (averageResult) {
+      averageResult.textContent = message;
+    }
+    if (statsAverageText) {
+      statsAverageText.textContent = message;
+    }
     return stats;
   }
 
   if (stats.invalidRange) {
     const message = "Start date cannot be after end date.";
-    averageResult.textContent = message;
-    statsAverageText.textContent = message;
+    if (averageResult) {
+      averageResult.textContent = message;
+    }
+    if (statsAverageText) {
+      statsAverageText.textContent = message;
+    }
     return stats;
   }
 
   if (stats.entries.length === 0) {
     const message = "No memories in the selected range.";
-    averageResult.textContent = message;
-    statsAverageText.textContent = message;
+    if (averageResult) {
+      averageResult.textContent = message;
+    }
+    if (statsAverageText) {
+      statsAverageText.textContent = message;
+    }
     return stats;
   }
 
   const averageValue = Number(stats.average).toFixed(2);
   const summary = `Average intensity ${describeRange(stats)}: ${averageValue}`;
-  averageResult.textContent = summary;
-  statsAverageText.textContent = summary;
+  if (averageResult) {
+    averageResult.textContent = summary;
+  }
+  if (statsAverageText) {
+    statsAverageText.textContent = summary;
+  }
   return stats;
 }
 

--- a/MemoryLedgerApp/wwwroot/index.html
+++ b/MemoryLedgerApp/wwwroot/index.html
@@ -28,6 +28,11 @@
             <button type="submit" class="primary">Create diary</button>
           </form>
         </section>
+        <section class="card">
+          <h2>Statistics</h2>
+          <p class="hint">Review intensity trends for your memories.</p>
+          <button type="button" id="statistics-button" class="secondary">Open statistics</button>
+        </section>
       </aside>
       <section class="content">
         <div id="message" class="message hidden" role="status" aria-live="polite"></div>
@@ -70,15 +75,6 @@
                 <button type="button" id="reset-search" class="secondary">Reset</button>
               </div>
             </form>
-            <form id="average-form" class="form-grid">
-              <h3>Average intensity</h3>
-              <label for="average-start">Start date</label>
-              <input id="average-start" name="start" type="date" />
-              <label for="average-end">End date</label>
-              <input id="average-end" name="end" type="date" />
-              <button type="submit" id="statistics-button" class="secondary">View statistics</button>
-              <p id="average-result" class="hint"></p>
-            </form>
           </section>
           <section>
             <h3>Memories</h3>
@@ -94,6 +90,19 @@
           <h2 id="stats-modal-title">Diary statistics</h2>
           <button type="button" id="stats-close" class="icon-button" aria-label="Close">×</button>
         </div>
+        <form id="average-form" class="form-grid stats-filter-form">
+          <div class="stats-filter-grid">
+            <div class="stats-filter-field">
+              <label for="average-start">Start date</label>
+              <input id="average-start" name="start" type="date" />
+            </div>
+            <div class="stats-filter-field">
+              <label for="average-end">End date</label>
+              <input id="average-end" name="end" type="date" />
+            </div>
+          </div>
+          <p id="average-result" class="hint"></p>
+        </form>
         <p id="stats-average" class="hint"></p>
         <div id="stats-chart-wrapper" class="stats-chart-wrapper hidden">
           <canvas id="stats-chart" aria-label="Diary intensity chart" role="img"></canvas>

--- a/MemoryLedgerApp/wwwroot/styles.css
+++ b/MemoryLedgerApp/wwwroot/styles.css
@@ -49,6 +49,10 @@ p {
   gap: 1.5rem;
 }
 
+.sidebar #statistics-button {
+  width: 100%;
+}
+
 .card {
   background: #ffffff;
   border-radius: 16px;
@@ -245,6 +249,21 @@ button.danger {
   align-items: center;
   margin-bottom: 1rem;
   gap: 1rem;
+}
+
+.stats-filter-form {
+  margin-bottom: 0.75rem;
+}
+
+.stats-filter-grid {
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.stats-filter-field {
+  display: grid;
+  gap: 0.35rem;
 }
 
 .modal-actions {


### PR DESCRIPTION
## Summary
- add a statistics card in the sidebar with a modal trigger and relocate the date filters into the modal
- style the new sidebar button and modal filter grid to match the existing design
- refresh statistics rendering when the modal is already open and guard summary updates when elements are absent

## Testing
- dotnet build MemoryLedgerApp/MemoryLedgerApp.csproj *(fails: `dotnet` command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d8fbaf47888326a05d2684b7dacccb