### PR TITLE
Convert open diary form into modal

### DIFF
--- a/MemoryLedgerApp/wwwroot/index.html
+++ b/MemoryLedgerApp/wwwroot/index.html
@@ -16,7 +16,7 @@
         <section class="card">
           <h2>Available diaries</h2>
           <ul id="diary-list" class="diary-list"></ul>
-          <p class="hint">Use the password field below to open or delete a diary.</p>
+          <p class="hint">Click a diary to enter its password and open it.</p>
         </section>
         <section class="card">
           <h2>Create a diary</h2>
@@ -31,19 +31,6 @@
       </aside>
       <section class="content">
         <div id="message" class="message hidden" role="status" aria-live="polite"></div>
-        <section class="card">
-          <h2>Open a diary</h2>
-          <form id="open-diary-form" class="form-grid">
-            <label for="open-name">Name</label>
-            <input id="open-name" name="name" type="text" required />
-            <label for="open-password">Password</label>
-            <input id="open-password" name="password" type="password" required />
-            <div class="button-row">
-              <button type="submit" class="primary">Open diary</button>
-              <button type="button" id="delete-diary" class="danger">Delete diary</button>
-            </div>
-          </form>
-        </section>
         <section id="diary-view" class="card hidden">
           <div class="diary-header">
             <div>
@@ -54,6 +41,7 @@
               <button type="button" id="add-entry" class="primary">Add memory</button>
               <button type="button" id="refresh-diary" class="secondary">Refresh</button>
               <button type="button" id="close-diary" class="secondary">Close</button>
+              <button type="button" id="delete-diary" class="danger hidden">Delete diary</button>
             </div>
           </div>
           <section class="forms-grid">
@@ -99,6 +87,24 @@
           <canvas id="stats-chart" aria-label="Diary intensity chart" role="img"></canvas>
         </div>
         <p id="stats-empty" class="hint hidden"></p>
+      </div>
+    </div>
+    <div id="open-modal" class="modal hidden" role="dialog" aria-modal="true" aria-labelledby="open-modal-title">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h2 id="open-modal-title">Open a diary</h2>
+          <button type="button" id="open-close" class="icon-button" aria-label="Close">×</button>
+        </div>
+        <form id="open-diary-form" class="form-grid">
+          <label for="open-name">Name</label>
+          <input id="open-name" name="name" type="text" required />
+          <label for="open-password">Password</label>
+          <input id="open-password" name="password" type="password" required />
+          <div class="modal-actions">
+            <button type="button" id="open-cancel" class="secondary">Cancel</button>
+            <button type="submit" class="primary">Open diary</button>
+          </div>
+        </form>
       </div>
     </div>
     <div id="entry-modal" class="modal hidden" role="dialog" aria-modal="true" aria-labelledby="entry-modal-title">

--- a/MemoryLedgerApp/wwwroot/styles.css
+++ b/MemoryLedgerApp/wwwroot/styles.css
@@ -97,6 +97,14 @@ p {
   padding: 0.65rem 0.75rem;
   font-weight: 600;
   color: #1d4ed8;
+  cursor: pointer;
+}
+
+.diary-list li:focus,
+.diary-list li:hover {
+  outline: none;
+  background: rgba(37, 99, 235, 0.15);
+  box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.25);
 }
 
 .form-grid {


### PR DESCRIPTION
## Summary
- convert the inline "Open a diary" section into a modal with dismiss controls
- open the modal when a diary is selected and close it after successful unlocks
- move the delete diary action into the diary header and refresh styles for clickable diary items

## Testing
- dotnet build MemoryLedgerApp/MemoryLedgerApp.csproj *(fails: dotnet not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d8fcc32abc83269748aec56ffdf02a