### PR TITLE
Move diary creation form into modal

### DIFF
--- a/MemoryLedgerApp/wwwroot/app.js
+++ b/MemoryLedgerApp/wwwroot/app.js
@@ -12,6 +12,10 @@ const openForm = document.getElementById("open-diary-form");
 const openModal = document.getElementById("open-modal");
 const openModalCloseButton = document.getElementById("open-close");
 const openModalCancelButton = document.getElementById("open-cancel");
+const createModal = document.getElementById("create-modal");
+const createModalCloseButton = document.getElementById("create-close");
+const createModalCancelButton = document.getElementById("create-cancel");
+const createDiaryButton = document.getElementById("create-diary-button");
 const deleteDiaryButton = document.getElementById("delete-diary");
 const refreshButton = document.getElementById("refresh-diary");
 const closeButton = document.getElementById("close-diary");
@@ -59,6 +63,26 @@ function init() {
     statisticsButton.disabled = true;
   }
 
+  if (createDiaryButton) {
+    createDiaryButton.addEventListener("click", () => {
+      openCreateModal();
+    });
+  }
+
+  createModalCloseButton.addEventListener("click", () => {
+    closeCreateModal();
+  });
+
+  createModalCancelButton.addEventListener("click", () => {
+    closeCreateModal();
+  });
+
+  createModal.addEventListener("click", (event) => {
+    if (event.target === createModal) {
+      closeCreateModal();
+    }
+  });
+
   openModalCloseButton.addEventListener("click", () => {
     closeOpenModal();
   });
@@ -83,6 +107,7 @@ function init() {
 
     if (response.ok) {
       createForm.reset();
+      closeCreateModal();
       loadDiaries();
     }
   });
@@ -155,7 +180,9 @@ function init() {
       return;
     }
 
-    if (isOpenModalOpen()) {
+    if (isCreateModalOpen()) {
+      closeCreateModal();
+    } else if (isOpenModalOpen()) {
       closeOpenModal();
     } else if (isStatsModalOpen()) {
       closeStatisticsModal();
@@ -301,6 +328,29 @@ async function openDiaryFromForm() {
   }
 
   await openDiary(name, password);
+}
+
+function openCreateModal() {
+  createForm.reset();
+  createModal.classList.remove("hidden");
+  document.body.classList.add("modal-open");
+  createForm.name.focus();
+}
+
+function closeCreateModal() {
+  if (createModal.classList.contains("hidden")) {
+    return;
+  }
+
+  createModal.classList.add("hidden");
+  createForm.reset();
+  if (!isAnyModalOpen()) {
+    document.body.classList.remove("modal-open");
+  }
+}
+
+function isCreateModalOpen() {
+  return !createModal.classList.contains("hidden");
 }
 
 function openDiaryModal(presetName = "") {
@@ -653,7 +703,12 @@ function isStatsModalOpen() {
 }
 
 function isAnyModalOpen() {
-  return isOpenModalOpen() || !entryModal.classList.contains("hidden") || isStatsModalOpen();
+  return (
+    isCreateModalOpen() ||
+    isOpenModalOpen() ||
+    !entryModal.classList.contains("hidden") ||
+    isStatsModalOpen()
+  );
 }
 
 async function openStatisticsModal() {

--- a/MemoryLedgerApp/wwwroot/index.html
+++ b/MemoryLedgerApp/wwwroot/index.html
@@ -14,19 +14,10 @@
     <main class="app-layout">
       <aside class="sidebar">
         <section class="card">
+          <button type="button" id="create-diary-button" class="primary full-width">Create diary</button>
           <h2>Available diaries</h2>
           <ul id="diary-list" class="diary-list"></ul>
           <p class="hint">Click a diary to enter its password and open it.</p>
-        </section>
-        <section class="card">
-          <h2>Create a diary</h2>
-          <form id="create-diary-form" class="form-grid">
-            <label for="create-name">Name</label>
-            <input id="create-name" name="name" type="text" required />
-            <label for="create-password">Password</label>
-            <input id="create-password" name="password" type="password" required />
-            <button type="submit" class="primary">Create diary</button>
-          </form>
         </section>
         <section class="card">
           <h2>Statistics</h2>
@@ -112,6 +103,24 @@
           <div class="modal-actions">
             <button type="button" id="open-cancel" class="secondary">Cancel</button>
             <button type="submit" class="primary">Open diary</button>
+          </div>
+        </form>
+      </div>
+    </div>
+    <div id="create-modal" class="modal hidden" role="dialog" aria-modal="true" aria-labelledby="create-modal-title">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h2 id="create-modal-title">Create a diary</h2>
+          <button type="button" id="create-close" class="icon-button" aria-label="Close">×</button>
+        </div>
+        <form id="create-diary-form" class="form-grid">
+          <label for="create-name">Name</label>
+          <input id="create-name" name="name" type="text" required />
+          <label for="create-password">Password</label>
+          <input id="create-password" name="password" type="password" required />
+          <div class="modal-actions">
+            <button type="button" id="create-cancel" class="secondary">Cancel</button>
+            <button type="submit" class="primary">Create diary</button>
           </div>
         </form>
       </div>

--- a/MemoryLedgerApp/wwwroot/styles.css
+++ b/MemoryLedgerApp/wwwroot/styles.css
@@ -49,6 +49,10 @@ p {
   gap: 1.5rem;
 }
 
+.full-width {
+  width: 100%;
+}
+
 .sidebar #statistics-button {
   width: 100%;
 }


### PR DESCRIPTION
## Summary
- replace the sidebar diary creation form with a dedicated modal dialog
- add a create diary button above the available diaries list and ensure styles support the layout
- wire up modal open/close behaviors in the front-end script

## Testing
- Not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d9129513988326a0601e829ff5a275