### PR TITLE
Add Windows Forms desktop client alongside web app

### DIFF
--- a/MemoryLedgerWinForms/Dialogs/DialogService.cs
+++ b/MemoryLedgerWinForms/Dialogs/DialogService.cs
@@ -1,0 +1,117 @@
+using System;
+using System.Drawing;
+using System.Windows.Forms;
+
+namespace MemoryLedgerWinForms.Dialogs;
+
+internal static class DialogService
+{
+    public static (string Name, string Password)? PromptForDiaryCreation(IWin32Window owner)
+    {
+        using var form = CreateBaseForm("Crear diario");
+        var nameLabel = new Label { Text = "Nombre", AutoSize = true, Dock = DockStyle.Fill, TextAlign = ContentAlignment.MiddleLeft };
+        var nameTextBox = new TextBox { Dock = DockStyle.Fill };
+        var passwordLabel = new Label { Text = "Contraseña", AutoSize = true, Dock = DockStyle.Fill, TextAlign = ContentAlignment.MiddleLeft };
+        var passwordTextBox = new TextBox { Dock = DockStyle.Fill, UseSystemPasswordChar = true };
+
+        var layout = CreateTwoColumnLayout();
+        layout.Controls.Add(nameLabel, 0, 0);
+        layout.Controls.Add(nameTextBox, 1, 0);
+        layout.Controls.Add(passwordLabel, 0, 1);
+        layout.Controls.Add(passwordTextBox, 1, 1);
+
+        var buttons = CreateButtonsPanel();
+        var okButton = new Button { Text = "Aceptar", DialogResult = DialogResult.OK, AutoSize = true };
+        var cancelButton = new Button { Text = "Cancelar", DialogResult = DialogResult.Cancel, AutoSize = true };
+        buttons.Controls.Add(cancelButton);
+        buttons.Controls.Add(okButton);
+
+        form.AcceptButton = okButton;
+        form.CancelButton = cancelButton;
+        form.Controls.Add(layout);
+        form.Controls.Add(buttons);
+        layout.Dock = DockStyle.Top;
+        buttons.Dock = DockStyle.Bottom;
+        form.Shown += (_, _) => nameTextBox.Focus();
+
+        if (form.ShowDialog(owner) == DialogResult.OK)
+        {
+            return (nameTextBox.Text.Trim(), passwordTextBox.Text);
+        }
+
+        return null;
+    }
+
+    public static string? PromptForPassword(IWin32Window owner, string diaryName)
+    {
+        var title = $"Contraseña para '{diaryName}'";
+        using var form = CreateBaseForm(title);
+        var messageLabel = new Label
+        {
+            Text = "Introduce la contraseña",
+            Dock = DockStyle.Top,
+            AutoSize = true,
+            Padding = new Padding(0, 0, 0, 8)
+        };
+        var passwordBox = new TextBox { Dock = DockStyle.Top, UseSystemPasswordChar = true };
+
+        var buttons = CreateButtonsPanel();
+        var okButton = new Button { Text = "Aceptar", DialogResult = DialogResult.OK, AutoSize = true };
+        var cancelButton = new Button { Text = "Cancelar", DialogResult = DialogResult.Cancel, AutoSize = true };
+        buttons.Controls.Add(cancelButton);
+        buttons.Controls.Add(okButton);
+
+        form.AcceptButton = okButton;
+        form.CancelButton = cancelButton;
+        form.Controls.Add(messageLabel);
+        form.Controls.Add(passwordBox);
+        form.Controls.Add(buttons);
+        passwordBox.Margin = new Padding(10, 0, 10, 0);
+        messageLabel.Margin = new Padding(10, 10, 10, 0);
+        buttons.Dock = DockStyle.Bottom;
+        form.Shown += (_, _) => passwordBox.Focus();
+
+        return form.ShowDialog(owner) == DialogResult.OK
+            ? passwordBox.Text
+            : null;
+    }
+
+    private static Form CreateBaseForm(string title) => new()
+    {
+        Text = title,
+        StartPosition = FormStartPosition.CenterParent,
+        FormBorderStyle = FormBorderStyle.FixedDialog,
+        MinimizeBox = false,
+        MaximizeBox = false,
+        ClientSize = new Size(380, 160)
+    };
+
+    private static TableLayoutPanel CreateTwoColumnLayout() => new()
+    {
+        ColumnCount = 2,
+        RowCount = 2,
+        Dock = DockStyle.Top,
+        Padding = new Padding(10),
+        AutoSize = true,
+        AutoSizeMode = AutoSizeMode.GrowAndShrink,
+        ColumnStyles =
+        {
+            new ColumnStyle(SizeType.Absolute, 110F),
+            new ColumnStyle(SizeType.Percent, 100F)
+        },
+        RowStyles =
+        {
+            new RowStyle(SizeType.AutoSize),
+            new RowStyle(SizeType.AutoSize)
+        }
+    };
+
+    private static FlowLayoutPanel CreateButtonsPanel() => new()
+    {
+        FlowDirection = FlowDirection.RightToLeft,
+        Padding = new Padding(10),
+        Dock = DockStyle.Bottom,
+        AutoSize = true,
+        AutoSizeMode = AutoSizeMode.GrowAndShrink
+    };
+}

--- a/MemoryLedgerWinForms/MainForm.Designer.cs
+++ b/MemoryLedgerWinForms/MainForm.Designer.cs
@@ -1,0 +1,479 @@
+using System.Windows.Forms;
+
+namespace MemoryLedgerWinForms;
+
+partial class MainForm
+{
+    /// <summary>
+    ///  Required designer variable.
+    /// </summary>
+    private System.ComponentModel.IContainer? components = null;
+
+    /// <summary>
+    ///  Clean up any resources being used.
+    /// </summary>
+    /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing && (components != null))
+        {
+            components.Dispose();
+        }
+        base.Dispose(disposing);
+    }
+
+    #region Windows Form Designer generated code
+
+    /// <summary>
+    ///  Required method for Designer support - do not modify
+    ///  the contents of this method with the code editor.
+    /// </summary>
+    private void InitializeComponent()
+    {
+        components = new System.ComponentModel.Container();
+        mainLayout = new TableLayoutPanel();
+        diariesGroupBox = new GroupBox();
+        diariesLayout = new TableLayoutPanel();
+        diariesListBox = new ListBox();
+        diaryButtonsPanel = new FlowLayoutPanel();
+        refreshDiariesButton = new Button();
+        openDiaryButton = new Button();
+        createDiaryButton = new Button();
+        deleteDiaryButton = new Button();
+        entriesGroupBox = new GroupBox();
+        entriesLayout = new TableLayoutPanel();
+        currentDiaryLabel = new Label();
+        entriesListView = new ListView();
+        columnDate = new ColumnHeader();
+        columnTitle = new ColumnHeader();
+        columnIntensity = new ColumnHeader();
+        entryEditorLayout = new TableLayoutPanel();
+        entryDateLabel = new Label();
+        entryDatePicker = new DateTimePicker();
+        entryTitleLabel = new Label();
+        entryTitleTextBox = new TextBox();
+        entryDescriptionLabel = new Label();
+        entryDescriptionTextBox = new TextBox();
+        entryIntensityLabel = new Label();
+        entryIntensityNumericUpDown = new NumericUpDown();
+        entryButtonsPanel = new FlowLayoutPanel();
+        addEntryButton = new Button();
+        updateEntryButton = new Button();
+        deleteEntryButton = new Button();
+        statusLabel = new Label();
+        mainLayout.SuspendLayout();
+        diariesGroupBox.SuspendLayout();
+        diariesLayout.SuspendLayout();
+        diaryButtonsPanel.SuspendLayout();
+        entriesGroupBox.SuspendLayout();
+        entriesLayout.SuspendLayout();
+        entryEditorLayout.SuspendLayout();
+        ((System.ComponentModel.ISupportInitialize)entryIntensityNumericUpDown).BeginInit();
+        entryButtonsPanel.SuspendLayout();
+        SuspendLayout();
+        // 
+        // mainLayout
+        // 
+        mainLayout.ColumnCount = 2;
+        mainLayout.ColumnStyles.Add(new ColumnStyle(SizeType.Absolute, 260F));
+        mainLayout.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 100F));
+        mainLayout.Controls.Add(diariesGroupBox, 0, 0);
+        mainLayout.Controls.Add(entriesGroupBox, 1, 0);
+        mainLayout.Dock = DockStyle.Fill;
+        mainLayout.Location = new System.Drawing.Point(0, 0);
+        mainLayout.Name = "mainLayout";
+        mainLayout.RowCount = 1;
+        mainLayout.RowStyles.Add(new RowStyle(SizeType.Percent, 100F));
+        mainLayout.Size = new System.Drawing.Size(1084, 661);
+        mainLayout.TabIndex = 0;
+        // 
+        // diariesGroupBox
+        // 
+        diariesGroupBox.Controls.Add(diariesLayout);
+        diariesGroupBox.Dock = DockStyle.Fill;
+        diariesGroupBox.Location = new System.Drawing.Point(3, 3);
+        diariesGroupBox.Name = "diariesGroupBox";
+        diariesGroupBox.Padding = new Padding(10);
+        diariesGroupBox.Size = new System.Drawing.Size(254, 655);
+        diariesGroupBox.TabIndex = 0;
+        diariesGroupBox.TabStop = false;
+        diariesGroupBox.Text = "Diarios";
+        // 
+        // diariesLayout
+        // 
+        diariesLayout.ColumnCount = 1;
+        diariesLayout.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 100F));
+        diariesLayout.Controls.Add(diariesListBox, 0, 0);
+        diariesLayout.Controls.Add(diaryButtonsPanel, 0, 1);
+        diariesLayout.Dock = DockStyle.Fill;
+        diariesLayout.Location = new System.Drawing.Point(10, 26);
+        diariesLayout.Name = "diariesLayout";
+        diariesLayout.RowCount = 2;
+        diariesLayout.RowStyles.Add(new RowStyle(SizeType.Percent, 100F));
+        diariesLayout.RowStyles.Add(new RowStyle(SizeType.AutoSize));
+        diariesLayout.Size = new System.Drawing.Size(234, 619);
+        diariesLayout.TabIndex = 0;
+        // 
+        // diariesListBox
+        // 
+        diariesListBox.Dock = DockStyle.Fill;
+        diariesListBox.FormattingEnabled = true;
+        diariesListBox.IntegralHeight = false;
+        diariesListBox.ItemHeight = 20;
+        diariesListBox.Location = new System.Drawing.Point(3, 3);
+        diariesListBox.Name = "diariesListBox";
+        diariesListBox.Size = new System.Drawing.Size(228, 556);
+        diariesListBox.TabIndex = 0;
+        // 
+        // diaryButtonsPanel
+        // 
+        diaryButtonsPanel.AutoSize = true;
+        diaryButtonsPanel.AutoSizeMode = AutoSizeMode.GrowAndShrink;
+        diaryButtonsPanel.Controls.Add(refreshDiariesButton);
+        diaryButtonsPanel.Controls.Add(openDiaryButton);
+        diaryButtonsPanel.Controls.Add(createDiaryButton);
+        diaryButtonsPanel.Controls.Add(deleteDiaryButton);
+        diaryButtonsPanel.Dock = DockStyle.Fill;
+        diaryButtonsPanel.FlowDirection = FlowDirection.TopDown;
+        diaryButtonsPanel.Location = new System.Drawing.Point(3, 565);
+        diaryButtonsPanel.Name = "diaryButtonsPanel";
+        diaryButtonsPanel.Size = new System.Drawing.Size(228, 51);
+        diaryButtonsPanel.TabIndex = 1;
+        diaryButtonsPanel.WrapContents = false;
+        // 
+        // refreshDiariesButton
+        // 
+        refreshDiariesButton.AutoSize = true;
+        refreshDiariesButton.Location = new System.Drawing.Point(3, 3);
+        refreshDiariesButton.Name = "refreshDiariesButton";
+        refreshDiariesButton.Size = new System.Drawing.Size(79, 35);
+        refreshDiariesButton.TabIndex = 0;
+        refreshDiariesButton.Text = "Actualizar";
+        refreshDiariesButton.UseVisualStyleBackColor = true;
+        // 
+        // openDiaryButton
+        // 
+        openDiaryButton.AutoSize = true;
+        openDiaryButton.Location = new System.Drawing.Point(3, 44);
+        openDiaryButton.Name = "openDiaryButton";
+        openDiaryButton.Size = new System.Drawing.Size(57, 35);
+        openDiaryButton.TabIndex = 1;
+        openDiaryButton.Text = "Abrir";
+        openDiaryButton.UseVisualStyleBackColor = true;
+        // 
+        // createDiaryButton
+        // 
+        createDiaryButton.AutoSize = true;
+        createDiaryButton.Location = new System.Drawing.Point(3, 85);
+        createDiaryButton.Name = "createDiaryButton";
+        createDiaryButton.Size = new System.Drawing.Size(68, 35);
+        createDiaryButton.TabIndex = 2;
+        createDiaryButton.Text = "Crear";
+        createDiaryButton.UseVisualStyleBackColor = true;
+        // 
+        // deleteDiaryButton
+        // 
+        deleteDiaryButton.AutoSize = true;
+        deleteDiaryButton.Location = new System.Drawing.Point(3, 126);
+        deleteDiaryButton.Margin = new Padding(3, 3, 3, 0);
+        deleteDiaryButton.Name = "deleteDiaryButton";
+        deleteDiaryButton.Size = new System.Drawing.Size(71, 35);
+        deleteDiaryButton.TabIndex = 3;
+        deleteDiaryButton.Text = "Eliminar";
+        deleteDiaryButton.UseVisualStyleBackColor = true;
+        // 
+        // entriesGroupBox
+        // 
+        entriesGroupBox.Controls.Add(entriesLayout);
+        entriesGroupBox.Dock = DockStyle.Fill;
+        entriesGroupBox.Location = new System.Drawing.Point(263, 3);
+        entriesGroupBox.Name = "entriesGroupBox";
+        entriesGroupBox.Padding = new Padding(10);
+        entriesGroupBox.Size = new System.Drawing.Size(818, 655);
+        entriesGroupBox.TabIndex = 1;
+        entriesGroupBox.TabStop = false;
+        entriesGroupBox.Text = "Recuerdos";
+        // 
+        // entriesLayout
+        // 
+        entriesLayout.ColumnCount = 1;
+        entriesLayout.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 100F));
+        entriesLayout.Controls.Add(currentDiaryLabel, 0, 0);
+        entriesLayout.Controls.Add(entriesListView, 0, 1);
+        entriesLayout.Controls.Add(entryEditorLayout, 0, 2);
+        entriesLayout.Controls.Add(entryButtonsPanel, 0, 3);
+        entriesLayout.Controls.Add(statusLabel, 0, 4);
+        entriesLayout.Dock = DockStyle.Fill;
+        entriesLayout.Location = new System.Drawing.Point(10, 26);
+        entriesLayout.Name = "entriesLayout";
+        entriesLayout.RowCount = 5;
+        entriesLayout.RowStyles.Add(new RowStyle(SizeType.AutoSize));
+        entriesLayout.RowStyles.Add(new RowStyle(SizeType.Percent, 50F));
+        entriesLayout.RowStyles.Add(new RowStyle(SizeType.Percent, 50F));
+        entriesLayout.RowStyles.Add(new RowStyle(SizeType.AutoSize));
+        entriesLayout.RowStyles.Add(new RowStyle(SizeType.AutoSize));
+        entriesLayout.Size = new System.Drawing.Size(798, 619);
+        entriesLayout.TabIndex = 0;
+        // 
+        // currentDiaryLabel
+        // 
+        currentDiaryLabel.AutoSize = true;
+        currentDiaryLabel.Dock = DockStyle.Fill;
+        currentDiaryLabel.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point);
+        currentDiaryLabel.Location = new System.Drawing.Point(3, 0);
+        currentDiaryLabel.Name = "currentDiaryLabel";
+        currentDiaryLabel.Padding = new Padding(0, 0, 0, 8);
+        currentDiaryLabel.Size = new System.Drawing.Size(792, 23);
+        currentDiaryLabel.TabIndex = 0;
+        currentDiaryLabel.Text = "Selecciona un diario y haz clic en \"Abrir\".";
+        // 
+        // entriesListView
+        // 
+        entriesListView.Columns.AddRange(new ColumnHeader[] { columnDate, columnTitle, columnIntensity });
+        entriesListView.Dock = DockStyle.Fill;
+        entriesListView.FullRowSelect = true;
+        entriesListView.HideSelection = false;
+        entriesListView.Location = new System.Drawing.Point(3, 26);
+        entriesListView.MultiSelect = false;
+        entriesListView.Name = "entriesListView";
+        entriesListView.Size = new System.Drawing.Size(792, 282);
+        entriesListView.TabIndex = 1;
+        entriesListView.UseCompatibleStateImageBehavior = false;
+        entriesListView.View = View.Details;
+        // 
+        // columnDate
+        // 
+        columnDate.Text = "Fecha";
+        columnDate.Width = 120;
+        // 
+        // columnTitle
+        // 
+        columnTitle.Text = "Título";
+        columnTitle.Width = 420;
+        // 
+        // columnIntensity
+        // 
+        columnIntensity.Text = "Intensidad";
+        columnIntensity.Width = 120;
+        // 
+        // entryEditorLayout
+        // 
+        entryEditorLayout.ColumnCount = 2;
+        entryEditorLayout.ColumnStyles.Add(new ColumnStyle(SizeType.Absolute, 120F));
+        entryEditorLayout.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 100F));
+        entryEditorLayout.Controls.Add(entryDateLabel, 0, 0);
+        entryEditorLayout.Controls.Add(entryDatePicker, 1, 0);
+        entryEditorLayout.Controls.Add(entryTitleLabel, 0, 1);
+        entryEditorLayout.Controls.Add(entryTitleTextBox, 1, 1);
+        entryEditorLayout.Controls.Add(entryDescriptionLabel, 0, 2);
+        entryEditorLayout.Controls.Add(entryDescriptionTextBox, 1, 2);
+        entryEditorLayout.Controls.Add(entryIntensityLabel, 0, 3);
+        entryEditorLayout.Controls.Add(entryIntensityNumericUpDown, 1, 3);
+        entryEditorLayout.Dock = DockStyle.Fill;
+        entryEditorLayout.Location = new System.Drawing.Point(3, 314);
+        entryEditorLayout.Name = "entryEditorLayout";
+        entryEditorLayout.RowCount = 4;
+        entryEditorLayout.RowStyles.Add(new RowStyle(SizeType.AutoSize));
+        entryEditorLayout.RowStyles.Add(new RowStyle(SizeType.AutoSize));
+        entryEditorLayout.RowStyles.Add(new RowStyle(SizeType.Percent, 100F));
+        entryEditorLayout.RowStyles.Add(new RowStyle(SizeType.AutoSize));
+        entryEditorLayout.Size = new System.Drawing.Size(792, 282);
+        entryEditorLayout.TabIndex = 2;
+        // 
+        // entryDateLabel
+        // 
+        entryDateLabel.AutoSize = true;
+        entryDateLabel.Dock = DockStyle.Fill;
+        entryDateLabel.Location = new System.Drawing.Point(3, 0);
+        entryDateLabel.Name = "entryDateLabel";
+        entryDateLabel.Padding = new Padding(0, 6, 0, 6);
+        entryDateLabel.Size = new System.Drawing.Size(114, 34);
+        entryDateLabel.TabIndex = 0;
+        entryDateLabel.Text = "Fecha";
+        // 
+        // entryDatePicker
+        // 
+        entryDatePicker.Dock = DockStyle.Left;
+        entryDatePicker.Format = DateTimePickerFormat.Short;
+        entryDatePicker.Location = new System.Drawing.Point(123, 3);
+        entryDatePicker.Name = "entryDatePicker";
+        entryDatePicker.Size = new System.Drawing.Size(160, 27);
+        entryDatePicker.TabIndex = 1;
+        // 
+        // entryTitleLabel
+        // 
+        entryTitleLabel.AutoSize = true;
+        entryTitleLabel.Dock = DockStyle.Fill;
+        entryTitleLabel.Location = new System.Drawing.Point(3, 34);
+        entryTitleLabel.Name = "entryTitleLabel";
+        entryTitleLabel.Padding = new Padding(0, 6, 0, 6);
+        entryTitleLabel.Size = new System.Drawing.Size(114, 34);
+        entryTitleLabel.TabIndex = 2;
+        entryTitleLabel.Text = "Título";
+        // 
+        // entryTitleTextBox
+        // 
+        entryTitleTextBox.Dock = DockStyle.Fill;
+        entryTitleTextBox.Location = new System.Drawing.Point(123, 37);
+        entryTitleTextBox.Name = "entryTitleTextBox";
+        entryTitleTextBox.Size = new System.Drawing.Size(666, 27);
+        entryTitleTextBox.TabIndex = 3;
+        // 
+        // entryDescriptionLabel
+        // 
+        entryDescriptionLabel.AutoSize = true;
+        entryDescriptionLabel.Dock = DockStyle.Fill;
+        entryDescriptionLabel.Location = new System.Drawing.Point(3, 68);
+        entryDescriptionLabel.Name = "entryDescriptionLabel";
+        entryDescriptionLabel.Padding = new Padding(0, 6, 0, 6);
+        entryDescriptionLabel.Size = new System.Drawing.Size(114, 196);
+        entryDescriptionLabel.TabIndex = 4;
+        entryDescriptionLabel.Text = "Descripción";
+        // 
+        // entryDescriptionTextBox
+        // 
+        entryDescriptionTextBox.Dock = DockStyle.Fill;
+        entryDescriptionTextBox.Location = new System.Drawing.Point(123, 71);
+        entryDescriptionTextBox.Multiline = true;
+        entryDescriptionTextBox.Name = "entryDescriptionTextBox";
+        entryDescriptionTextBox.ScrollBars = ScrollBars.Vertical;
+        entryDescriptionTextBox.Size = new System.Drawing.Size(666, 190);
+        entryDescriptionTextBox.TabIndex = 5;
+        // 
+        // entryIntensityLabel
+        // 
+        entryIntensityLabel.AutoSize = true;
+        entryIntensityLabel.Dock = DockStyle.Fill;
+        entryIntensityLabel.Location = new System.Drawing.Point(3, 264);
+        entryIntensityLabel.Name = "entryIntensityLabel";
+        entryIntensityLabel.Padding = new Padding(0, 6, 0, 6);
+        entryIntensityLabel.Size = new System.Drawing.Size(114, 48);
+        entryIntensityLabel.TabIndex = 6;
+        entryIntensityLabel.Text = "Intensidad (1-10)";
+        // 
+        // entryIntensityNumericUpDown
+        // 
+        entryIntensityNumericUpDown.Dock = DockStyle.Left;
+        entryIntensityNumericUpDown.Location = new System.Drawing.Point(123, 267);
+        entryIntensityNumericUpDown.Maximum = new decimal(new int[] { 10, 0, 0, 0 });
+        entryIntensityNumericUpDown.Minimum = new decimal(new int[] { 1, 0, 0, 0 });
+        entryIntensityNumericUpDown.Name = "entryIntensityNumericUpDown";
+        entryIntensityNumericUpDown.Size = new System.Drawing.Size(80, 27);
+        entryIntensityNumericUpDown.TabIndex = 7;
+        entryIntensityNumericUpDown.Value = new decimal(new int[] { 5, 0, 0, 0 });
+        // 
+        // entryButtonsPanel
+        // 
+        entryButtonsPanel.AutoSize = true;
+        entryButtonsPanel.Controls.Add(addEntryButton);
+        entryButtonsPanel.Controls.Add(updateEntryButton);
+        entryButtonsPanel.Controls.Add(deleteEntryButton);
+        entryButtonsPanel.Dock = DockStyle.Fill;
+        entryButtonsPanel.FlowDirection = FlowDirection.RightToLeft;
+        entryButtonsPanel.Location = new System.Drawing.Point(3, 602);
+        entryButtonsPanel.Name = "entryButtonsPanel";
+        entryButtonsPanel.Size = new System.Drawing.Size(792, 35);
+        entryButtonsPanel.TabIndex = 3;
+        // 
+        // addEntryButton
+        // 
+        addEntryButton.AutoSize = true;
+        addEntryButton.Location = new System.Drawing.Point(672, 3);
+        addEntryButton.Name = "addEntryButton";
+        addEntryButton.Size = new System.Drawing.Size(117, 29);
+        addEntryButton.TabIndex = 0;
+        addEntryButton.Text = "Añadir recuerdo";
+        addEntryButton.UseVisualStyleBackColor = true;
+        // 
+        // updateEntryButton
+        // 
+        updateEntryButton.AutoSize = true;
+        updateEntryButton.Location = new System.Drawing.Point(536, 3);
+        updateEntryButton.Name = "updateEntryButton";
+        updateEntryButton.Size = new System.Drawing.Size(130, 29);
+        updateEntryButton.TabIndex = 1;
+        updateEntryButton.Text = "Actualizar actual";
+        updateEntryButton.UseVisualStyleBackColor = true;
+        // 
+        // deleteEntryButton
+        // 
+        deleteEntryButton.AutoSize = true;
+        deleteEntryButton.Location = new System.Drawing.Point(400, 3);
+        deleteEntryButton.Name = "deleteEntryButton";
+        deleteEntryButton.Size = new System.Drawing.Size(130, 29);
+        deleteEntryButton.TabIndex = 2;
+        deleteEntryButton.Text = "Eliminar actual";
+        deleteEntryButton.UseVisualStyleBackColor = true;
+        // 
+        // statusLabel
+        // 
+        statusLabel.AutoSize = true;
+        statusLabel.Dock = DockStyle.Fill;
+        statusLabel.ForeColor = System.Drawing.Color.DimGray;
+        statusLabel.Location = new System.Drawing.Point(3, 640);
+        statusLabel.Margin = new Padding(3, 0, 3, 3);
+        statusLabel.Name = "statusLabel";
+        statusLabel.Size = new System.Drawing.Size(792, 16);
+        statusLabel.TabIndex = 4;
+        statusLabel.Text = "Listo.";
+        // 
+        // MainForm
+        // 
+        AutoScaleDimensions = new System.Drawing.SizeF(8F, 20F);
+        AutoScaleMode = AutoScaleMode.Font;
+        ClientSize = new System.Drawing.Size(1084, 661);
+        Controls.Add(mainLayout);
+        MinimumSize = new System.Drawing.Size(900, 600);
+        Name = "MainForm";
+        StartPosition = FormStartPosition.CenterScreen;
+        Text = "Memory Ledger";
+        mainLayout.ResumeLayout(false);
+        diariesGroupBox.ResumeLayout(false);
+        diariesLayout.ResumeLayout(false);
+        diariesLayout.PerformLayout();
+        diaryButtonsPanel.ResumeLayout(false);
+        diaryButtonsPanel.PerformLayout();
+        entriesGroupBox.ResumeLayout(false);
+        entriesLayout.ResumeLayout(false);
+        entriesLayout.PerformLayout();
+        entryEditorLayout.ResumeLayout(false);
+        entryEditorLayout.PerformLayout();
+        ((System.ComponentModel.ISupportInitialize)entryIntensityNumericUpDown).EndInit();
+        entryButtonsPanel.ResumeLayout(false);
+        entryButtonsPanel.PerformLayout();
+        ResumeLayout(false);
+    }
+
+    #endregion
+
+    private TableLayoutPanel mainLayout;
+    private GroupBox diariesGroupBox;
+    private TableLayoutPanel diariesLayout;
+    private ListBox diariesListBox;
+    private FlowLayoutPanel diaryButtonsPanel;
+    private Button refreshDiariesButton;
+    private Button openDiaryButton;
+    private Button createDiaryButton;
+    private Button deleteDiaryButton;
+    private GroupBox entriesGroupBox;
+    private TableLayoutPanel entriesLayout;
+    private Label currentDiaryLabel;
+    private ListView entriesListView;
+    private ColumnHeader columnDate;
+    private ColumnHeader columnTitle;
+    private ColumnHeader columnIntensity;
+    private TableLayoutPanel entryEditorLayout;
+    private Label entryDateLabel;
+    private DateTimePicker entryDatePicker;
+    private Label entryTitleLabel;
+    private TextBox entryTitleTextBox;
+    private Label entryDescriptionLabel;
+    private TextBox entryDescriptionTextBox;
+    private Label entryIntensityLabel;
+    private NumericUpDown entryIntensityNumericUpDown;
+    private FlowLayoutPanel entryButtonsPanel;
+    private Button addEntryButton;
+    private Button updateEntryButton;
+    private Button deleteEntryButton;
+    private Label statusLabel;
+}

--- a/MemoryLedgerWinForms/MainForm.cs
+++ b/MemoryLedgerWinForms/MainForm.cs
@@ -1,0 +1,393 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+using MemoryLedgerApp.Models;
+using MemoryLedgerApp.Services;
+using MemoryLedgerWinForms.Dialogs;
+
+namespace MemoryLedgerWinForms;
+
+public partial class MainForm : Form
+{
+    private readonly DiaryStorage _storage;
+    private DiarySession? _currentSession;
+
+    public MainForm(DiaryStorage storage)
+    {
+        _storage = storage;
+        InitializeComponent();
+        HookEvents();
+        UpdateDiaryButtons();
+        UpdateEntryControls();
+        LoadDiaries();
+    }
+
+    private void HookEvents()
+    {
+        refreshDiariesButton.Click += (_, _) => LoadDiaries();
+        createDiaryButton.Click += async (_, _) => await CreateDiaryAsync();
+        openDiaryButton.Click += async (_, _) => await OpenSelectedDiaryAsync();
+        deleteDiaryButton.Click += async (_, _) => await DeleteSelectedDiaryAsync();
+        diariesListBox.DoubleClick += async (_, _) => await OpenSelectedDiaryAsync();
+        diariesListBox.SelectedIndexChanged += (_, _) => UpdateDiaryButtons();
+
+        entriesListView.SelectedIndexChanged += (_, _) => OnEntrySelectionChanged();
+        entriesListView.DoubleClick += (_, _) => LoadSelectedEntryIntoEditor();
+        addEntryButton.Click += async (_, _) => await AddEntryAsync();
+        updateEntryButton.Click += async (_, _) => await UpdateEntryAsync();
+        deleteEntryButton.Click += async (_, _) => await DeleteEntryAsync();
+    }
+
+    private void LoadDiaries()
+    {
+        var previousSelection = diariesListBox.SelectedItem?.ToString() ?? _currentSession?.Diary.Name;
+        var diaries = _storage.ListDiaries().ToList();
+        diariesListBox.BeginUpdate();
+        diariesListBox.Items.Clear();
+        diariesListBox.Items.AddRange(diaries.Cast<object>().ToArray());
+        diariesListBox.EndUpdate();
+
+        if (!string.IsNullOrWhiteSpace(previousSelection))
+        {
+            SelectDiary(previousSelection);
+        }
+
+        UpdateDiaryButtons();
+        SetStatus(diaries.Count == 0 ? "No hay diarios disponibles." : $"{diaries.Count} diario(s) disponibles.");
+    }
+
+    private async Task CreateDiaryAsync()
+    {
+        var result = DialogService.PromptForDiaryCreation(this);
+        if (result is null)
+        {
+            return;
+        }
+
+        var (name, password) = result.Value;
+        if (string.IsNullOrWhiteSpace(name) || string.IsNullOrWhiteSpace(password))
+        {
+            MessageBox.Show(this, "El nombre y la contraseña son obligatorios.", "Datos incompletos", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+            return;
+        }
+
+        try
+        {
+            await _storage.CreateDiaryAsync(name.Trim(), password.Trim());
+            LoadDiaries();
+            SelectDiary(name);
+            SetStatus($"Diario '{name}' creado correctamente.");
+        }
+        catch (InvalidOperationException ex)
+        {
+            MessageBox.Show(this, ex.Message, "No se pudo crear", MessageBoxButtons.OK, MessageBoxIcon.Error);
+        }
+    }
+
+    private async Task OpenSelectedDiaryAsync()
+    {
+        if (diariesListBox.SelectedItem is not string diaryName)
+        {
+            MessageBox.Show(this, "Selecciona un diario de la lista.", "Ningún diario seleccionado", MessageBoxButtons.OK, MessageBoxIcon.Information);
+            return;
+        }
+
+        var password = DialogService.PromptForPassword(this, diaryName);
+        if (password is null)
+        {
+            return;
+        }
+
+        try
+        {
+            var diary = await _storage.LoadDiaryAsync(diaryName, password);
+            _currentSession = new DiarySession(diary, password, _storage);
+            currentDiaryLabel.Text = $"Diario abierto: {diaryName}";
+            PopulateEntries();
+            ClearEntryEditor();
+            UpdateEntryControls();
+            SetStatus($"Diario '{diaryName}' abierto correctamente.");
+        }
+        catch (UnauthorizedAccessException)
+        {
+            MessageBox.Show(this, "Contraseña incorrecta.", "Acceso denegado", MessageBoxButtons.OK, MessageBoxIcon.Error);
+        }
+        catch (FileNotFoundException)
+        {
+            MessageBox.Show(this, "El diario ya no existe.", "No encontrado", MessageBoxButtons.OK, MessageBoxIcon.Error);
+            LoadDiaries();
+        }
+    }
+
+    private async Task DeleteSelectedDiaryAsync()
+    {
+        if (diariesListBox.SelectedItem is not string diaryName)
+        {
+            MessageBox.Show(this, "Selecciona un diario de la lista.", "Ningún diario seleccionado", MessageBoxButtons.OK, MessageBoxIcon.Information);
+            return;
+        }
+
+        var password = DialogService.PromptForPassword(this, diaryName);
+        if (password is null)
+        {
+            return;
+        }
+
+        var confirm = MessageBox.Show(this, $"¿Seguro que deseas eliminar el diario '{diaryName}'?", "Confirmar eliminación", MessageBoxButtons.YesNo, MessageBoxIcon.Warning);
+        if (confirm != DialogResult.Yes)
+        {
+            return;
+        }
+
+        try
+        {
+            // Validar la contraseña antes de eliminar.
+            await _storage.LoadDiaryAsync(diaryName, password);
+            _storage.DeleteDiary(diaryName);
+            if (_currentSession?.Diary.Name == diaryName)
+            {
+                CloseCurrentSession();
+            }
+
+            LoadDiaries();
+            SetStatus($"Diario '{diaryName}' eliminado correctamente.");
+        }
+        catch (UnauthorizedAccessException)
+        {
+            MessageBox.Show(this, "Contraseña incorrecta.", "Acceso denegado", MessageBoxButtons.OK, MessageBoxIcon.Error);
+        }
+        catch (FileNotFoundException)
+        {
+            MessageBox.Show(this, "El diario ya no existe.", "No encontrado", MessageBoxButtons.OK, MessageBoxIcon.Error);
+            LoadDiaries();
+        }
+    }
+
+    private void PopulateEntries()
+    {
+        entriesListView.BeginUpdate();
+        entriesListView.Items.Clear();
+
+        if (_currentSession is not null)
+        {
+            foreach (var entry in _currentSession.GetEntriesOrderedByDateDesc())
+            {
+                var item = new ListViewItem(entry.Date.ToString("yyyy-MM-dd"))
+                {
+                    Tag = entry
+                };
+                item.SubItems.Add(entry.Title);
+                item.SubItems.Add(entry.Intensity.ToString());
+                entriesListView.Items.Add(item);
+            }
+        }
+
+        entriesListView.EndUpdate();
+        UpdateEntryControls();
+    }
+
+    private async Task AddEntryAsync()
+    {
+        if (!EnsureSessionActive())
+        {
+            return;
+        }
+
+        if (!TryGetEntryInput(out var date, out var title, out var description, out var intensity))
+        {
+            return;
+        }
+
+        var entry = _currentSession!.AddEntry(date, title, description, intensity);
+        await _currentSession.SaveAsync();
+        PopulateEntries();
+        SelectEntry(entry);
+        SetStatus("Recuerdo añadido correctamente.");
+    }
+
+    private async Task UpdateEntryAsync()
+    {
+        if (!EnsureSessionActive())
+        {
+            return;
+        }
+
+        if (GetSelectedEntry() is not MemoryEntry entry)
+        {
+            MessageBox.Show(this, "Selecciona el recuerdo que deseas actualizar.", "Sin selección", MessageBoxButtons.OK, MessageBoxIcon.Information);
+            return;
+        }
+
+        if (!TryGetEntryInput(out var date, out var title, out var description, out var intensity))
+        {
+            return;
+        }
+
+        _currentSession!.UpdateEntry(entry.Id, e =>
+        {
+            e.Date = date;
+            e.Title = title;
+            e.Description = description;
+            e.Intensity = intensity;
+        });
+
+        await _currentSession.SaveAsync();
+        PopulateEntries();
+        SelectEntry(entry);
+        SetStatus("Recuerdo actualizado correctamente.");
+    }
+
+    private async Task DeleteEntryAsync()
+    {
+        if (!EnsureSessionActive())
+        {
+            return;
+        }
+
+        if (GetSelectedEntry() is not MemoryEntry entry)
+        {
+            MessageBox.Show(this, "Selecciona el recuerdo que deseas eliminar.", "Sin selección", MessageBoxButtons.OK, MessageBoxIcon.Information);
+            return;
+        }
+
+        var confirm = MessageBox.Show(this, "¿Seguro que deseas eliminar este recuerdo?", "Confirmar", MessageBoxButtons.YesNo, MessageBoxIcon.Warning);
+        if (confirm != DialogResult.Yes)
+        {
+            return;
+        }
+
+        if (_currentSession!.DeleteEntry(entry.Id))
+        {
+            await _currentSession.SaveAsync();
+            PopulateEntries();
+            ClearEntryEditor();
+            SetStatus("Recuerdo eliminado correctamente.");
+        }
+    }
+
+    private void OnEntrySelectionChanged()
+    {
+        LoadSelectedEntryIntoEditor();
+        UpdateEntryControls();
+    }
+
+    private void LoadSelectedEntryIntoEditor()
+    {
+        if (GetSelectedEntry() is MemoryEntry entry)
+        {
+            entryDatePicker.Value = entry.Date;
+            entryTitleTextBox.Text = entry.Title;
+            entryDescriptionTextBox.Text = entry.Description;
+            entryIntensityNumericUpDown.Value = Math.Clamp(entry.Intensity, (int)entryIntensityNumericUpDown.Minimum, (int)entryIntensityNumericUpDown.Maximum);
+        }
+    }
+
+    private void ClearEntryEditor()
+    {
+        entryDatePicker.Value = DateTime.Today;
+        entryTitleTextBox.Clear();
+        entryDescriptionTextBox.Clear();
+        entryIntensityNumericUpDown.Value = 5;
+    }
+
+    private void SelectDiary(string diaryName)
+    {
+        for (var i = 0; i < diariesListBox.Items.Count; i++)
+        {
+            if (string.Equals(diaryName, diariesListBox.Items[i]?.ToString(), StringComparison.OrdinalIgnoreCase))
+            {
+                diariesListBox.SelectedIndex = i;
+                break;
+            }
+        }
+    }
+
+    private void SelectEntry(MemoryEntry entry)
+    {
+        foreach (ListViewItem item in entriesListView.Items)
+        {
+            if (item.Tag is MemoryEntry current && current.Id == entry.Id)
+            {
+                item.Selected = true;
+                item.EnsureVisible();
+                break;
+            }
+        }
+    }
+
+    private MemoryEntry? GetSelectedEntry() => entriesListView.SelectedItems.Count == 0
+        ? null
+        : entriesListView.SelectedItems[0].Tag as MemoryEntry;
+
+    private bool TryGetEntryInput(out DateTime date, out string title, out string description, out int intensity)
+    {
+        date = entryDatePicker.Value.Date;
+        title = entryTitleTextBox.Text.Trim();
+        description = entryDescriptionTextBox.Text.Trim();
+        intensity = (int)entryIntensityNumericUpDown.Value;
+
+        if (string.IsNullOrWhiteSpace(title))
+        {
+            MessageBox.Show(this, "El título es obligatorio.", "Dato requerido", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+            entryTitleTextBox.Focus();
+            return false;
+        }
+
+        if (string.IsNullOrWhiteSpace(description))
+        {
+            MessageBox.Show(this, "La descripción es obligatoria.", "Dato requerido", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+            entryDescriptionTextBox.Focus();
+            return false;
+        }
+
+        return true;
+    }
+
+    private bool EnsureSessionActive()
+    {
+        if (_currentSession is null)
+        {
+            MessageBox.Show(this, "Abre un diario antes de gestionar recuerdos.", "Ningún diario abierto", MessageBoxButtons.OK, MessageBoxIcon.Information);
+            return false;
+        }
+
+        return true;
+    }
+
+    private void CloseCurrentSession()
+    {
+        _currentSession = null;
+        currentDiaryLabel.Text = "Selecciona un diario y haz clic en \"Abrir\".";
+        entriesListView.Items.Clear();
+        ClearEntryEditor();
+        UpdateEntryControls();
+    }
+
+    private void UpdateDiaryButtons()
+    {
+        var hasSelection = diariesListBox.SelectedItem is string;
+        openDiaryButton.Enabled = hasSelection;
+        deleteDiaryButton.Enabled = hasSelection;
+    }
+
+    private void UpdateEntryControls()
+    {
+        var hasSession = _currentSession is not null;
+        var hasSelection = GetSelectedEntry() is not null;
+
+        entryDatePicker.Enabled = hasSession;
+        entryTitleTextBox.Enabled = hasSession;
+        entryDescriptionTextBox.Enabled = hasSession;
+        entryIntensityNumericUpDown.Enabled = hasSession;
+        addEntryButton.Enabled = hasSession;
+        updateEntryButton.Enabled = hasSession && hasSelection;
+        deleteEntryButton.Enabled = hasSession && hasSelection;
+    }
+
+    private void SetStatus(string message)
+    {
+        statusLabel.Text = message;
+    }
+}

--- a/MemoryLedgerWinForms/MemoryLedgerWinForms.csproj
+++ b/MemoryLedgerWinForms/MemoryLedgerWinForms.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net8.0-windows</TargetFramework>
+    <UseWindowsForms>true</UseWindowsForms>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <EnableWindowsTargeting>true</EnableWindowsTargeting>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="../MemoryLedgerApp/Models/**/*.cs">
+      <Link>Shared/Models/%(RecursiveDir)%(Filename)%(Extension)</Link>
+    </Compile>
+    <Compile Include="../MemoryLedgerApp/Services/**/*.cs">
+      <Link>Shared/Services/%(RecursiveDir)%(Filename)%(Extension)</Link>
+    </Compile>
+    <Compile Include="../MemoryLedgerApp/Utilities/EncryptionService.cs">
+      <Link>Shared/Utilities/EncryptionService.cs</Link>
+    </Compile>
+  </ItemGroup>
+</Project>

--- a/MemoryLedgerWinForms/Program.cs
+++ b/MemoryLedgerWinForms/Program.cs
@@ -1,0 +1,18 @@
+using System;
+using System.Windows.Forms;
+using MemoryLedgerApp.Services;
+
+namespace MemoryLedgerWinForms;
+
+internal static class Program
+{
+    [STAThread]
+    private static void Main()
+    {
+        Application.EnableVisualStyles();
+        Application.SetCompatibleTextRenderingDefault(false);
+
+        var storage = new DiaryStorage(AppContext.BaseDirectory);
+        Application.Run(new MainForm(storage));
+    }
+}

--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
 # MemoryLedger
 
-## MemoryLedgerApp (console skeleton)
+MemoryLedger es un conjunto de herramientas para gestionar diarios cifrados de recuerdos. El repositorio incluye dos interfaces que comparten el mismo backend de almacenamiento y cifrado:
 
-`MemoryLedgerApp` es una aplicación de consola escrita en C# (.NET 8) pensada como esqueleto funcional para gestionar diarios cifrados de recuerdos. El objetivo principal es disponer de una base portable (sin instalador) que permita evolucionar la solución.
+- **MemoryLedgerApp**: API mínima en ASP.NET Core con interfaz web estática incluida en `wwwroot`.
+- **MemoryLedgerWinForms**: cliente de escritorio en Windows Forms para trabajar sin navegador.
 
-### Características clave
+Ambas aplicaciones guardan los diarios como archivos cifrados (`.mlg`) en una carpeta `diaries` junto al ejecutable utilizado.
 
-- Gestión de múltiples diarios protegidos mediante contraseña. Cada diario se almacena en disco como un archivo independiente cifrado (AES-256 CBC + PBKDF2).
-- Alta, edición, búsqueda y eliminación de recuerdos con los campos: identificador numérico, fecha, título, descripción e intensidad.
-- Listado de recuerdos ordenado por fecha descendente.
-- Informe básico de intensidad media en un rango de fechas (por defecto, último año).
+## MemoryLedgerApp (interfaz web)
+
+`MemoryLedgerApp` expone una API minimalista que sirve una SPA ligera incluida en `wwwroot`. Permite crear diarios protegidos por contraseña, abrirlos y administrar recuerdos.
 
 ### Ejecución local
 
@@ -18,9 +18,30 @@
    ```bash
    dotnet run --project MemoryLedgerApp
    ```
-3. Los diarios se guardan en la subcarpeta `MemoryLedgerApp/bin/Debug/net8.0/diaries` (o la correspondiente al modo de compilación) junto al ejecutable publicado.
+3. Abre un navegador y visita `http://localhost:5000` (o el puerto indicado en la consola).
 
-Para crear distribuciones portables se puede usar `dotnet publish` con la opción `--self-contained` y el runtime correspondiente (win-x64, linux-x64, osx-arm64, etc.).
+## MemoryLedgerWinForms (cliente de escritorio)
+
+El proyecto `MemoryLedgerWinForms` ofrece una alternativa de escritorio sin necesidad de navegador. Reutiliza los modelos, servicios y cifrado de la API, pero presenta una interfaz gráfica tradicional con listas, formularios y cuadros de diálogo.
+
+> ℹ️ Requiere Windows para su ejecución, aunque puede compilarse desde otros sistemas gracias a `EnableWindowsTargeting`.
+
+### Ejecución en Windows
+
+1. Instala el SDK de [.NET 8](https://dotnet.microsoft.com/download).
+2. Desde la carpeta raíz del repositorio ejecuta:
+   ```bash
+   dotnet run --project MemoryLedgerWinForms
+   ```
+3. Los diarios se crean y leen en la carpeta `diaries` situada junto al ejecutable (`bin/Debug/net8.0-windows/diaries` en modo debug).
+
+Para distribuirlo como aplicación portable puedes usar:
+
+```bash
+dotnet publish MemoryLedgerWinForms -c Release -r win-x64 --self-contained true
+```
+
+Esto generará un ejecutable que incluye el runtime de .NET.
 
 ---
 


### PR DESCRIPTION
## Summary
- add a new MemoryLedgerWinForms project that targets net8.0-windows and links to the shared models, services, and encryption helpers
- implement a WinForms main window and dialog helpers to manage diaries and entries using the existing DiaryStorage/DiarySession logic
- document how to run both the web API and the new desktop client in the README

## Testing
- not run (dotnet CLI is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68d9308b374c8326a25a2d3ffe3e95ba