### PR TITLE
Fix DateTimePicker filter event wiring

### DIFF
--- a/MemoryLedgerWinForms/Dialogs/StatisticsForm.cs
+++ b/MemoryLedgerWinForms/Dialogs/StatisticsForm.cs
@@ -47,9 +47,7 @@ public partial class StatisticsForm : Form
     private void HookEvents()
     {
         startDatePicker.ValueChanged += OnFiltersChanged;
-        startDatePicker.CheckedChanged += OnFiltersChanged;
         endDatePicker.ValueChanged += OnFiltersChanged;
-        endDatePicker.CheckedChanged += OnFiltersChanged;
     }
 
     private void OnFiltersChanged(object? sender, EventArgs e)


### PR DESCRIPTION
## Summary
- remove subscriptions to the non-existent DateTimePicker.CheckedChanged event in StatisticsForm
- rely on the existing ValueChanged events to refresh statistics when filters change

## Testing
- not run (dotnet CLI not available in environment)


------
https://chatgpt.com/codex/tasks/task_e_68d959d22ae4832689b87537fc2b3e07